### PR TITLE
Update normalization methods

### DIFF
--- a/R/proteoQ-peptable.R
+++ b/R/proteoQ-peptable.R
@@ -518,6 +518,7 @@ normPep <- function (id = c("pep_seq", "pep_seq_mod"),
 	}
 
 	dir.create(file.path(dat_dir, "Peptide\\log"), recursive = TRUE, showWarnings = FALSE)
+
 	quietly_out <- purrr::quietly(normMulGau)(
 	  df = df,
 	  method_align = method_align,
@@ -550,25 +551,27 @@ normPep <- function (id = c("pep_seq", "pep_seq_mod"),
 		dplyr::mutate_if(is.logical, as.numeric) %>%
 		round(., digits = 0)
 	
-	df <- df %>% 
-	  dplyr::select(-one_of(
-	    "m/z", "Scan number", "Scan index", "Length", "Deamidation (N) Probabilities", 
-	    "Oxidation (M) Probabilities", "Deamidation (N) Score Diffs", "Oxidation (M) Score Diffs", 
-	    "Acetyl (Protein N-term)", "Deamidation (N)", "Glu->pyro-Glu", "Oxidation (M)", 
-	    "Charge", "Fragmentation", "Mass analyzer", "Type", "Scan event number", 
-	    "Isotope index", "Mass", "Mass error [ppm]", "Mass error [Da]", 
-	    "Simple mass error [ppm]", "Retention time", "Delta score", "Score diff", 
-	    "Localization prob", "Combinatorics", "PIF", 
-	    "Fraction of total spectrum", "Base peak fraction", "Precursor Full ScanNumber", 
-	    "Precursor Intensity", "Precursor Apex Fraction", "Precursor Apex Offset", 
-	    "Precursor Apex Offset Time", "Matches", "Intensities", "Mass Deviations [Da]", 
-	    "Mass Deviations [ppm]", "Masses", "Number of Matches", "Intensity coverage", "Peak coverage", 
-	    "Neutral loss level", "ETD identification type", "Reverse", "All scores", "All sequences", 
-	    "All modified sequences", "Reporter PIF", "Reporter fraction", "ID", "Protein group IDs", 
-	    "Peptide ID", "Mod. peptide ID", "Evidence ID", "Deamidation (N) site IDs", 
-	    "Oxidation (M) site IDs"
-	  )) %>% 
-	  dplyr::select(-grep("^Reporter mass deviation", names(.)))
+	suppressWarnings(
+	  df <- df %>% 
+	    dplyr::select(-one_of(
+	      "m/z", "Scan number", "Scan index", "Length", "Deamidation (N) Probabilities", 
+	      "Oxidation (M) Probabilities", "Deamidation (N) Score Diffs", "Oxidation (M) Score Diffs", 
+	      "Acetyl (Protein N-term)", "Deamidation (N)", "Glu->pyro-Glu", "Oxidation (M)", 
+	      "Charge", "Fragmentation", "Mass analyzer", "Type", "Scan event number", 
+	      "Isotope index", "Mass", "Mass error [ppm]", "Mass error [Da]", 
+	      "Simple mass error [ppm]", "Retention time", "Delta score", "Score diff", 
+	      "Localization prob", "Combinatorics", "PIF", 
+	      "Fraction of total spectrum", "Base peak fraction", "Precursor Full ScanNumber", 
+	      "Precursor Intensity", "Precursor Apex Fraction", "Precursor Apex Offset", 
+	      "Precursor Apex Offset Time", "Matches", "Intensities", "Mass Deviations [Da]", 
+	      "Mass Deviations [ppm]", "Masses", "Number of Matches", "Intensity coverage", "Peak coverage", 
+	      "Neutral loss level", "ETD identification type", "Reverse", "All scores", "All sequences", 
+	      "All modified sequences", "Reporter PIF", "Reporter fraction", "ID", "Protein group IDs", 
+	      "Peptide ID", "Mod. peptide ID", "Evidence ID", "Deamidation (N) site IDs", 
+	      "Oxidation (M) site IDs"
+	    )) %>% 
+	    dplyr::select(-grep("^Reporter mass deviation", names(.)))
+	)
 
 	write.table(df, file.path(dat_dir, "Peptide", "Peptide.txt"), sep = "\t",
 	            col.names = TRUE, row.names = FALSE)

--- a/R/proteoQ-string.R
+++ b/R/proteoQ-string.R
@@ -80,8 +80,6 @@ dl_stringdbs <- function(species = NULL, db_path = "~\\proteoQ\\dbs\\string", ov
                  stop("Unknown `species`.", Call. = FALSE)
   )
   
-
-  # species <- rlang::as_string(rlang::enexpr(species))
   abbr_species <- sp_lookup(species) 
   taxid <- taxid_lookup(species)
   

--- a/man/model_onechannel.Rd
+++ b/man/model_onechannel.Rd
@@ -10,7 +10,7 @@ pval_cutoff for adjP
 logFC_cutoff}
 \usage{
 model_onechannel(df, id, formula, label_scheme_sub, complete_cases, method,
-  var_cutoff, pval_cutoff, logFC_cutoff)
+  var_cutoff, pval_cutoff, logFC_cutoff, ...)
 }
 \description{
 Factorial model formula for interaction terms

--- a/man/prepFml.Rd
+++ b/man/prepFml.Rd
@@ -4,7 +4,7 @@
 \alias{prepFml}
 \title{Prepare formulas}
 \usage{
-prepFml(formula, label_scheme_sub)
+prepFml(formula, label_scheme_sub, ...)
 }
 \description{
 Prepare formulas


### PR DESCRIPTION
Allow going back and forth in the number of Gaussian components in data normalization; for example: first normalize data with normPep(n_comp = 3, ...) then renormalize data with normPep(n_comp = 2, ...).