### PR TITLE
Update 2019-11-21

### DIFF
--- a/R/proteoQ-peptable.R
+++ b/R/proteoQ-peptable.R
@@ -107,7 +107,7 @@ normPep_Splex <- function (id = "pep_seq_mod", method_psm_pep = "median", group_
 
 	  df <- df %>% 
 	    dplyr::select(-which(names(.) %in% c(
-	      "number", 
+	      "number", "modifications", 
 	      "variableSites", "nterm", "previous_aa", "sequence", "next_aa", 
 	      "cys", "searchCycle", "L/H", "accession_numbers", "entry_name", 
 	      "matched_parent_mass"))) 
@@ -683,6 +683,7 @@ med_summarise_keys <- function(df, id) {
   
   # Spectrum Mill keys
   sm_median_keys <- c(
+    "score", "parent_charge", 
     "deltaForwardReverseScore", "percent_scored_peak_intensity", "totalIntensity", 
     "precursorAveragineChiSquared", "precursorIsolationPurityPercent", 
     "precursorIsolationIntensity", "ratioReporterIonToPrecursor", 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ title: "Package proteoQ"
 author:
 - name: Qiang Zhang
 - name: R. Reid Townsend
-date: "2019-11-20"
+date: "2019-11-21"
 output:
   html_document:
     fig_caption: yes

--- a/man/annotPSM_sm.Rd
+++ b/man/annotPSM_sm.Rd
@@ -7,7 +7,8 @@
 \usage{
 annotPSM_sm(group_psm_by = "pep_seq", group_pep_by = "prot_acc",
   fasta = NULL, expt_smry = "expt_smry.xlsx", rm_krts = FALSE,
-  plot_rptr_int = TRUE, plot_log2FC_cv = TRUE, ...)
+  plot_rptr_int = TRUE, plot_log2FC_cv = TRUE,
+  use_lowercase_aa = TRUE, ...)
 }
 \arguments{
 \item{group_psm_by}{A character string for the grouping of PSM entries. At the


### PR DESCRIPTION
revert column keys to the original names of `parent_charge`, `score`, and `modifications` when summarising Spectrum Mill outputs