### PR TITLE
2020-04-18

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,5 @@
 ^LICENSE\.md$
-^READMD\.Rmd$
+^README\.Rmd$
 ^\.Rproj$
 ^\.Rproj\.user$
 ^cran-comments\.md$
@@ -7,4 +7,3 @@
 ^data-raw$
 ^\.github$
 ^images$
-^public$

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 inst/doc
 git
+blogdown
+public

--- a/R/informatics.R
+++ b/R/informatics.R
@@ -103,8 +103,8 @@ info_anal <- function (id = gene, col_select = NULL, col_group = NULL, col_order
 		col_group <- rlang::expr(Select)
 		warning("Column \'", rlang::as_string(col_group), "\' not found; use column \'Select\'.", call. = FALSE)
 	} else if (sum(!is.na(label_scheme[[col_group]])) == 0) {
-		col_group <- rlang::expr(Select)
 		warning("No samples under \'", rlang::as_string(col_group), "\'; use column \'Select\'.", call. = FALSE)
+		col_group <- rlang::expr(Select)
 	}
 
 	if (is.null(label_scheme[[col_order]])) {

--- a/R/psmtable.R
+++ b/R/psmtable.R
@@ -806,12 +806,11 @@ splitPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", fasta 
   # (1) the same `pep_query` can be assigned to different `pep_seq` at different `pep_rank`
   # (2) the same combination of `pep_query`, `pep_seq` and `pep_var_mod_pos` (positional difference) 
   # can be assigned to different `prot_acc` 
-  if ("pep_start" %in% names(df)) {
-    uniq_by <- c("pep_query", "pep_seq", "pep_var_mod_pos", "pep_start")
-  } else {
-    uniq_by <- c("pep_query", "pep_seq", "pep_var_mod_pos")
-  }
   
+  uniq_by <- c("pep_query", "pep_seq", "pep_var_mod_pos")
+  
+  if (length(unique(df$dat_file)) > 1) uniq_by <- c(uniq_by, "dat_file")
+
   df <- df %>% 
     tidyr::unite(uniq_id, uniq_by, sep = ".", remove = FALSE) %>% 
     dplyr::mutate(.n = row_number()) %>% 

--- a/vignettes/README.Rmd
+++ b/vignettes/README.Rmd
@@ -6,13 +6,6 @@ author:
 date: "`r Sys.Date()`"
 always_allow_html: true
 output:
-  github_document:
-    toc: yes
-  pdf_document:
-    toc: yes
-    number_sections: true
-  word_document:
-    toc: yes
   html_document:
     fig_caption: yes
     highlight: haddock
@@ -21,6 +14,13 @@ output:
     toc: yes
     toc_depth: 4
     toc_float: yes
+  pdf_document:
+    toc: yes
+    number_sections: true
+  word_document:
+    toc: yes
+  github_document:
+    toc: yes
   md_document:
     toc: yes
     toc_depth: 4
@@ -83,7 +83,7 @@ knitr::opts_chunk$set(
 ## Introduction to proteoQ
 Chemical labeling using tandem mass tag ([TMT](https://en.wikipedia.org/wiki/Tandem_mass_tag)) has been commonly applied in mass spectrometry (MS)-based quantification of proteins and peptides. The `proteoQ` tool is designed for automated and reproducible analysis of proteomics data. It interacts with an `Excel` spread sheet for dynamic sample selections, aesthetics controls and statistical modelings. It further integrates the operations against data rows and columns into functions at the users' interface. The arrangements allow users to put *ad hoc* manipulation of data behind the scene and instead apply metadata to openly address biological questions using various data preprocessing and informatic tools. In addition, the entire workflow is documented and can be conveniently reproduced upon revisiting.  
 
-The [framework](https://proteoq.netlify.com/#posts) of `proteoQ` consists of data processing and informatics analysis. It first processes the peptide spectrum matches (PSM) tables from [Mascot](https://http://www.matrixscience.com/), [MaxQuant](https://www.maxquant.org/) and [Spectrum Mill](https://www.agilent.com/en/products/software-informatics/masshunter-suite/masshunter-for-life-science-research/spectrum-mill) searches, for 6-, 10- 11- or 16-plex TMT experiments using Thermo's Orbitrap mass analyzers. Peptide and protein results are then produced with users' selection of parameters in data filtration, alignment and normalization. The package further offers a suite of tools and functionalities in statistics, informatics and data visualization by creating 'wrappers' around published R routines.^[To cite this work: (2019) R package proteoQ for Quantitative Proteomics Using Tandem Mass Tags. https://github.com/qzhang503/proteoQ.]  
+The [framework](https://proteoq.netlify.app/post/how-do-i-run-proteoq/) of `proteoQ` consists of data processing and informatics analysis. It first processes the peptide spectrum matches (PSM) tables from [Mascot](https://http://www.matrixscience.com/), [MaxQuant](https://www.maxquant.org/) and [Spectrum Mill](https://www.agilent.com/en/products/software-informatics/masshunter-suite/masshunter-for-life-science-research/spectrum-mill) searches, for 6-, 10- 11- or 16-plex TMT experiments using Thermo's Orbitrap mass analyzers. Peptide and protein results are then produced with users' selection of parameters in data filtration, alignment and normalization. The package further offers a suite of tools and functionalities in statistics, informatics and data visualization by creating 'wrappers' around published R routines.^[To cite this work: (2019) R package proteoQ for Quantitative Proteomics Using Tandem Mass Tags. https://github.com/qzhang503/proteoQ.]  
 
 (Click <strong>[Recent Posts](https://proteoq.netlify.com/#posts)</strong> for additional examples.)  
 


### PR DESCRIPTION
Bug fixes:
  - In Mascot workflows,
	  changed (back) the criterion of non-redundant peptides to the unique combination of
	  c("pep_query", "pep_seq", "pep_var_mod_pos"). In an earlier commit, it was made to
		c("pep_query", "pep_seq", "pep_var_mod_pos", "pep_start") to handle a future use of UniGene, which will fail when the option `Unique peptides only` in the interface of Mascot Report being `unchecked`.
  - In Mascot workflows,
	  in the case of the same MS data being searched for multiple times,
	  criterion of non-redundant peptides is c("pep_query", "pep_seq", "pep_var_mod_pos", "dat_file") where `dat_file` is the search-result file name