### PR TITLE
2020-05-20

### DIFF
--- a/R/specialty.R
+++ b/R/specialty.R
@@ -84,6 +84,13 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
   
   if (length(filelist) == 0) stop(paste("No PSM files under", file.path(dat_dir, "PSM")))
   
+  if (length(filelist) != 4) stop("Nee all four PSM files using search parameters of:\n", 
+                                  "1. TMT at both N-terminal and K\n", 
+                                  "2. TMT at N-terminal but not K\n", 
+                                  "3. TMT at K but not N-terminal\n",
+                                  "4. TMT on neither N-terminal or K",
+                                  call. = FALSE)
+  
   df <- purrr::map(filelist, ~ {
     df <- read.delim(file.path(dat_dir, "PSM\\cache", .x), sep = ',', check.names = FALSE, 
                      header = TRUE, stringsAsFactors = FALSE, quote = "\"",fill = TRUE , skip = 0)

--- a/R/utils.R
+++ b/R/utils.R
@@ -806,6 +806,7 @@ parse_acc <- function(df) {
   prn_acc <- df %>%
     dplyr::filter(!grepl("^REV__", prot_acc)) %>% 
     dplyr::filter(!grepl("^CON__", prot_acc)) %>% 
+    dplyr::filter(!grepl("\\|$", prot_acc)) %>% 
     dplyr::select(prot_acc) %>%
     unlist %>%
     .[1]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 proteoQ
 ================
 true
-2020-04-15
+2020-05-20
 
   - [Introduction to proteoQ](#introduction-to-proteoq)
   - [Installation](#installation)
@@ -12,17 +12,18 @@ true
       - [1.4 Peptides to proteins](#peptides-to-proteins)
       - [1.5 Workflow scripts](#workflow-scripts)
   - [2 Basic informatics](#basic-informatics)
-      - [2.1 MDS and PCA plots](#mds-and-pca-plots)
-      - [2.2 Correlation plots](#correlation-plots)
-      - [2.3 Heat maps](#heat-maps)
-      - [2.4 Significance tests](#significance-tests)
-      - [2.5 Gene sets under volcano
+      - [2.1 MDS](#mds)
+      - [2.2 PCA](#pca)
+      - [2.3 Correlation plots](#correlation-plots)
+      - [2.4 Heat maps](#heat-maps)
+      - [2.5 Significance tests](#significance-tests)
+      - [2.6 Gene sets under volcano
         plots](#gene-sets-under-volcano-plots)
-      - [2.6 Gene set networks](#gene-set-networks)
-      - [2.7 Trend Analysis](#trend-analysis)
-      - [2.8 NMF Analysis](#nmf-analysis)
-      - [2.9 STRING Analysis](#string-analysis)
-      - [2.9 Missing value imputation](#missing-value-imputation)
+      - [2.7 Gene set networks](#gene-set-networks)
+      - [2.8 Trend Analysis](#trend-analysis)
+      - [2.9 NMF Analysis](#nmf-analysis)
+      - [2.10 STRING Analysis](#string-analysis)
+      - [2.11 Missing value imputation](#missing-value-imputation)
   - [3 Labs](#labs)
       - [3.1 Reference choices](#reference-choices)
       - [3.2 Data subsets and additions](#data-subsets-and-additions)
@@ -47,9 +48,9 @@ apply metadata to openly address biological questions using various data
 preprocessing and informatic tools. In addition, the entire workflow is
 documented and can be conveniently reproduced upon revisiting.
 
-The [framework](https://proteoq.netlify.com/#posts) of `proteoQ`
-consists of data processing and informatics analysis. It first processes
-the peptide spectrum matches (PSM) tables from
+The [framework](https://proteoq.netlify.app/post/how-do-i-run-proteoq/)
+of `proteoQ` consists of data processing and informatics analysis. It
+first processes the peptide spectrum matches (PSM) tables from
 [Mascot](https://http://www.matrixscience.com/),
 [MaxQuant](https://www.maxquant.org/) and [Spectrum
 Mill](https://www.agilent.com/en/products/software-informatics/masshunter-suite/masshunter-for-life-science-research/spectrum-mill)
@@ -71,8 +72,7 @@ more properly under html.)
 
 ## Installation
 
-To install this package, start R (version “3.6.3”) as **administrator**
-and enter:
+To install this package, start R (version “4.1”) and enter:
 
 ``` r
 if (!requireNamespace("devtools", quietly = TRUE))
@@ -84,7 +84,7 @@ It will install the latest version by default or a specific version with
 a version number:
 
 ``` r
-devtools::install_github("qzhang503/proteoQ@1.2.2.1")
+devtools::install_github("qzhang503/proteoQ@1.2.2.2")
 ```
 
 ## 1 Data normalization
@@ -1211,10 +1211,10 @@ varargs of `filter_` is available throughout this section of informatic
 analysis. Row ordering of data, indicated by `arrange_`, is available
 for heat map applications using `pepHM`, `prnHM` and `plot_metaNMF`.
 
-### 2.1 MDS and PCA plots
+### 2.1 MDS
 
-We first visualize MDS, PCA and Euclidean distance against the peptide
-data. We start with metric MDS for peptide data:
+We first visualize MDS and Euclidean distance against the peptide data.
+We start with metric MDS for peptide data (`prnMDS` for proteins):
 
 ``` r
 # all data
@@ -1290,10 +1290,6 @@ pepMDS(
   width = 8,
 )
 ```
-
-Accordingly, the `prnMDS` performs `MDS` for protein data. For `PCA`
-analysis, the corresponding functions are `pepPCA` and `prnPCA` for
-peptide and protein data, respectively.
 
 While `MDS` approximates Euclidean and other distance measures at a
 low-dimensional space. Sometimes it may be useful to have an accurate
@@ -1390,7 +1386,14 @@ the cases that sample differences are exceedingly greater than handling
 errors, the setting of `adjEucDist = FALSE` would probably be more
 appropriate.
 
-### 2.2 Correlation plots
+### 2.2 PCA
+
+The utilities for PCA analysis are `pepPCA` and `prnPCA` for peptide and
+protein data, respectively. They are wrappers of the `stats::prcomp`.
+Additional notes about data centering and scaling can be found
+(<strong>[here](https://proteoq.netlify.app/post/wrapping-pca-into-proteoq/)</strong>).
+
+### 2.3 Correlation plots
 
 In this section, we visualize the batch effects and biological
 differences through correlation plots. The `proteoQ` tool currently
@@ -1441,7 +1444,7 @@ To visualize the correlation of intensity data, we can use
 `pepCorr_logInt` and `prnCorr_logInt` for peptide and protein data,
 respectively. More details can be assessed via `?pepCorr_logFC`.
 
-### 2.3 Heat maps
+### 2.4 Heat maps
 
 Heat map visualization is commonly applied in data sciences. The
 corresponding facilities in `proteoQ` are `pepHM` and `prnHM` for
@@ -1534,7 +1537,7 @@ row ordering.
 
 See `?standPep` for peptide examples.
 
-### 2.4 Significance tests
+### 2.5 Significance tests
 
 In this section, we perform the significance analysis of peptide and
 protein data. The approach of contrast fit (Chambers, J. M. Linear
@@ -1617,7 +1620,7 @@ additive random effects are also supported. More examples can be found
 via `?prnSig` and [Lab 3.3](###%203.3%20Random%20effects) in the
 document.
 
-### 2.5 Gene sets under volcano plots
+### 2.6 Gene sets under volcano plots
 
 There are a handful of `R` tools for gene set enrichement analysis, such
 as GSEA, GSVA, gage, to name a few. It may be intuitive as well if we
@@ -1838,7 +1841,7 @@ Gene set variance analysis (GSVA) is available through `prnGSVA`.
 Details can be found via `?prnGSEA` and `?prnGSVA`, respectively, from
 an `R` console.
 
-### 2.6 Gene set networks
+### 2.7 Gene set networks
 
 In the above section, we have plotted the enrichment of gene sets by
 individual GO or KEGG terms. Depending on how much the sample groups
@@ -1951,7 +1954,7 @@ distance \<= 0.8; right, distance \<= 0.2.
 
 </div>
 
-### 2.7 Trend Analysis
+### 2.8 Trend Analysis
 
 In this section, we perform the trend analysis against protein
 expressions. More information can be found from
@@ -2066,7 +2069,7 @@ from the `BI` subset whereas the later is based on the findings from all
 samples. The same theme will hold for various informatic analysis in
 `proteoQ`, including the NMF analysis that we will next discuss.
 
-### 2.8 NMF Analysis
+### 2.9 NMF Analysis
 
 In this section, we will performs the analysis of non-negative matrix
 factorization (NMF) against protein data. More details can be found from
@@ -2236,7 +2239,7 @@ plot_metaNMF(
 )
 ```
 
-### 2.9 STRING Analysis
+### 2.10 STRING Analysis
 
 The following performs the [`STRING`](http://www.string-db.org) analysis
 of protein-protein interactions. More details can be found from
@@ -2266,7 +2269,7 @@ dl_stringdbs(
 )
 ```
 
-### 2.9 Missing value imputation
+### 2.11 Missing value imputation
 
 Imputation of peptide and protein data are handle with `pepImp` and
 `prnImp`. More information can be found from

--- a/man/plotPCA.Rd
+++ b/man/plotPCA.Rd
@@ -136,6 +136,8 @@ against data in a primary file linked to \code{df}. See also
 \code{arrange_}: Variable argument statements for the row ordering against
 data in a primary file linked to \code{df}. See also \code{\link{prnHM}} for
 the format of \code{arrange_} statements. \cr \cr Additional parameters for
+\code{prcomp}: \cr \code{center}, data centering; \cr \code{tol}, the
+tolerance \cr \code{...} \cr \cr Additional parameters for
 \code{ggsave}: \cr \code{width}, the width of plot; \cr \code{height}, the
 height of plot \cr \code{...}}
 }

--- a/man/prnPCA.Rd
+++ b/man/prnPCA.Rd
@@ -154,6 +154,8 @@ against data in a primary file linked to \code{df}. See also
 \code{arrange_}: Variable argument statements for the row ordering against
 data in a primary file linked to \code{df}. See also \code{\link{prnHM}} for
 the format of \code{arrange_} statements. \cr \cr Additional parameters for
+\code{prcomp}: \cr \code{center}, data centering; \cr \code{tol}, the
+tolerance \cr \code{...} \cr \cr Additional parameters for
 \code{ggsave}: \cr \code{width}, the width of plot; \cr \code{height}, the
 height of plot \cr \code{...}}
 }

--- a/man/scorePCA.Rd
+++ b/man/scorePCA.Rd
@@ -42,6 +42,8 @@ against data in a primary file linked to \code{df}. See also
 \code{arrange_}: Variable argument statements for the row ordering against
 data in a primary file linked to \code{df}. See also \code{\link{prnHM}} for
 the format of \code{arrange_} statements. \cr \cr Additional parameters for
+\code{prcomp}: \cr \code{center}, data centering; \cr \code{tol}, the
+tolerance \cr \code{...} \cr \cr Additional parameters for
 \code{ggsave}: \cr \code{width}, the width of plot; \cr \code{height}, the
 height of plot \cr \code{...}}
 }

--- a/vignettes/README.Rmd
+++ b/vignettes/README.Rmd
@@ -6,6 +6,13 @@ author:
 date: "`r Sys.Date()`"
 always_allow_html: true
 output:
+  github_document:
+    toc: yes
+  pdf_document:
+    toc: yes
+    number_sections: true
+  word_document:
+    toc: yes
   html_document:
     fig_caption: yes
     highlight: haddock
@@ -14,13 +21,6 @@ output:
     toc: yes
     toc_depth: 4
     toc_float: yes
-  pdf_document:
-    toc: yes
-    number_sections: true
-  word_document:
-    toc: yes
-  github_document:
-    toc: yes
   md_document:
     toc: yes
     toc_depth: 4
@@ -90,7 +90,7 @@ The [framework](https://proteoq.netlify.app/post/how-do-i-run-proteoq/) of `prot
 (Click <strong>[here](https://htmlpreview.github.io/?https://github.com/qzhang503/proteoQ/blob/master/README.html)</strong> to render a html version of the README. Mathematical symbols may display more properly under html.)  
 
 ## Installation
-To install this package, start R (version "3.6.3") as **administrator** and enter:  
+To install this package, start R (version "4.1") and enter:  
 
 ```{r installation_1, include = TRUE, eval = FALSE}
 if (!requireNamespace("devtools", quietly = TRUE))
@@ -101,7 +101,7 @@ devtools::install_github("qzhang503/proteoQ")
 It will install the latest version by default or a specific version with a version number:  
 
 ```{r installation_2, include = TRUE, eval = FALSE}
-devtools::install_github("qzhang503/proteoQ@1.2.2.1")
+devtools::install_github("qzhang503/proteoQ@1.2.2.2")
 ```
 
 ## 1 Data normalization 
@@ -752,8 +752,8 @@ In this section I illustrate the following applications of `proteoQ`:
 
 Unless otherwise mentioned, the `in-function filtration` of data by varargs of `filter_` is available throughout this section of informatic analysis. Row ordering of data, indicated by `arrange_`, is available for heat map applications using `pepHM`, `prnHM` and `plot_metaNMF`.  
 
-### 2.1 MDS and PCA plots
-We first visualize MDS, PCA and Euclidean distance against the peptide data. We start with metric MDS for peptide data:  
+### 2.1 MDS
+We first visualize MDS and Euclidean distance against the peptide data. We start with metric MDS for peptide data (`prnMDS` for proteins):  
 
 ```{r Peptide MDS, eval = FALSE}
 # all data
@@ -800,8 +800,6 @@ pepMDS(
   width = 8,
 )
 ```
-
-Accordingly, the `prnMDS` performs `MDS` for protein data. For `PCA` analysis, the corresponding functions are `pepPCA` and `prnPCA` for peptide and protein data, respectively.  
 
 While `MDS` approximates Euclidean and other distance measures at a low-dimensional space. Sometimes it may be useful to have an accurate view of the distance matrix. Functions `pepEucDist` and `prnEucDist` plot the heat maps of Euclidean distance matrix for peptides and proteins, respectively. Supposed that we are interested in visualizing the distance matrix for the `JHU` subset:  
 
@@ -854,7 +852,10 @@ knitr::include_graphics(c(img_interplex_EucDist))
 
 The adjustment might be more suitable for studies where both the samples and references are largely similar in proteome compositions. The setting of `adjEucDist = TRUE` would discount the distances between references when using visualization techniques such a MDS or distance heat maps. In the cases that sample differences are exceedingly greater than handling errors, the setting of `adjEucDist = FALSE` would probably be more appropriate.  
 
-### 2.2 Correlation plots
+### 2.2 PCA 
+The utilities for PCA analysis are `pepPCA` and `prnPCA` for peptide and protein data, respectively. They are wrappers of the `stats::prcomp`. Additional notes about data centering and scaling can be found (<strong>[here](https://proteoq.netlify.app/post/wrapping-pca-into-proteoq/)</strong>).  
+
+### 2.3 Correlation plots
 In this section, we visualize the batch effects and biological differences through correlation plots. The `proteoQ` tool currently limits itself to a maximum of 44 samples for a correlation plot. In the document, we will perform correlation analysis against the `PNNL` data subset. By default, samples will be arranged by the alphabetical order for entries under the column `expt_smry.xlsx::Select`. We have learned from the earlier `MDS` analysis that the batch effects are smaller than the differences between `W2` and `W16`. We may wish to put the `TMT1` and `TMT2` groups adjacent to each other for visualization of more nuance batch effects, followed by the comparison of WHIM subtypes. We can achieve this by supervising sample IDs at a customized order. In the `expt_smry.xlsx`, We have prepared an `Order` column where samples within the `JHU` subset were arranged in the descending order of `W2.TMT1`, `W2.TMT2`, `W16.TMT1` and `W16.TMT2`. Now we tell the program to look for the `Order` column for sample arrangement:  
 
 ```{r correlation, eval = FALSE}
@@ -881,7 +882,7 @@ knitr::include_graphics(c(img_jhu_pepcorr, img_jhu_prncorr))
 
 To visualize the correlation of intensity data, we can use `pepCorr_logInt` and `prnCorr_logInt` for peptide and protein data, respectively. More details can be assessed via `?pepCorr_logFC`.  
 
-### 2.3 Heat maps
+### 2.4 Heat maps
 Heat map visualization is commonly applied in data sciences. The corresponding facilities in `proteoQ` are `pepHM` and `prnHM` for peptide and protein data, respectively. They are wrappers of [`pheatmap`](https://cran.r-project.org/web/packages/pheatmap/pheatmap.pdf) with modifications and exception handlings. More details can be found by accessing the help document via `?prnHM`.  
 
 The following shows an example of protein heat map:  
@@ -941,7 +942,7 @@ knitr::include_graphics(c(img_kinheat))
 
 See `?standPep` for peptide examples.  
 
-### 2.4 Significance tests
+### 2.5 Significance tests
 In this section, we perform the significance analysis of peptide and protein data. The approach of contrast fit (Chambers, J. M. Linear models, 1992; Gordon Smyth et al., `limma`) is taken in `proteoQ`. We will first define the contrast groups for significance tests. For this purpose, I have devided the samples by their WHIM subtypes, laboratory locations and batch numbers. This ends up with entries of `W2.BI.TMT1`, `W2.BI.TMT2` etc. under the `expt_smry.xlsx::Term` column. The interactive environment between the Excel file and the `proteoQ` tool allows us to enter more columns of contrasts when needed. For instance, we might also be interested in a more course comparison of inter-laboratory differences without batch effects. The corresponding contrasts of `W2.BI`, `W16.BI` etc. can be found under a pre-made column, `Term_2`. Having these columns in hand, we next perform significance tests and data visualization for peptide and protein data:  
 
 ```{r SigTest, eval = FALSE}
@@ -986,7 +987,7 @@ prnSig(
 
 In addition to the fixed effects shown above, significance tests with additive random effects are also supported. More examples can be found via `?prnSig` and [Lab 3.3](### 3.3 Random effects) in the document.  
 
-### 2.5 Gene sets under volcano plots
+### 2.6 Gene sets under volcano plots
 There are a handful of `R` tools for gene set enrichement analysis, such as GSEA, GSVA, gage, to name a few. It may be intuitive as well if we can analyze and visualize the enrichment of gene sets under the context of volcano plots at given contrasts. Provided the richness of `R` utilities in linear modelings, the `preoteoQ` takes a naive approach thereafter to assess the *asymmetricity* of protein probability $p$ values under volcano plots.  
 
 In the analysis of Gene Set Probability Asymmetricity (`GSPA`), protein significance $p$ values from linear modeling are first taken and separated into the groups of up or down expressed proteins within a gene set. The default is to calculate the geometric means, $P$, for each of the two groups with a penalty-like term:  
@@ -1130,7 +1131,7 @@ In addition to finding gene sets with significance, `prnGSPA` reports the essent
 
 The utility in `proteoQ` for conventional GSEA analysis is `prnGSEA()`. Gene set variance analysis (GSVA) is available through `prnGSVA`. Details can be found via `?prnGSEA` and `?prnGSVA`, respectively, from an `R` console.  
 
-### 2.6 Gene set networks
+### 2.7 Gene set networks
 In the above section, we have plotted the enrichment of gene sets by individual GO or KEGG terms. Depending on how much the sample groups contrast to each other, we could have produced more plots where many of them might never get viewed. Besides, gene sets can be redundant with overlaps to one another to varying degrees. A means to communicate the gene set results at high levels is to present them as hierarchical trees or grouped networks.  
 
 In this section, we will visualize the connectivity of significant gene sets by both distance heat maps and networks. For simplicity, the heat maps or networks will be constructed only between gene sets and essential gene sets. As mentioned in section `Gene sets under volcano plots`, the essential gene sets were approximated with greedy set cover. This will reduce the dimensionality of data from $n \times n$ to $n \times m$ ($m \le n$).  
@@ -1183,7 +1184,7 @@ knitr::include_graphics(c(img_gspahm_connect, img_gspahm_redund))
 ```
 
 
-### 2.7 Trend Analysis
+### 2.8 Trend Analysis
 In this section, we perform the trend analysis against protein expressions. More information can be found from [`cmeans`](https://www.rdocumentation.org/packages/e1071/versions/1.7-2/topics/cmeans),  [`Mfuzz`](https://www.bioconductor.org/packages/release/bioc/vignettes/Mfuzz/inst/doc/Mfuzz.pdf) and `?anal_prnTrend`. Note that the number of clusters is provided by `n_clust`, which can be a single value or a vector of integers.  
 
 ```{r Protein trends, eval = FALSE}
@@ -1256,7 +1257,7 @@ plot_prnTrend(col_select = BI, ...)
 
 Apparently, they will both plot the trends of protein log2FC for the `BI` subset. In spite, the former is based on the clustering results from the `BI` subset whereas the later is based on the findings from all samples.  The same theme will hold for various informatic analysis in `proteoQ`, including the NMF analysis that we will next discuss.  
 
-### 2.8 NMF Analysis
+### 2.9 NMF Analysis
 In this section, we will performs the analysis of non-negative matrix factorization (NMF) against protein data. More details can be found from [`NMF`](https://cran.r-project.org/web/packages/NMF/vignettes/NMF-vignette.pdf) and the `?anal_prnNMF` wrapper. Since additional arguments can be passed on to NMF, we will test below protein classifications with both the default and the 'lee' method:  
 
 ```{r Protein NMF, eval = FALSE}
@@ -1391,7 +1392,7 @@ plot_metaNMF(
 ```
 
 
-### 2.9 STRING Analysis
+### 2.10 STRING Analysis
 The following performs the [`STRING`](http://www.string-db.org) analysis of protein-protein interactions. More details can be found from `?anal_prnString`.  
 
 ```{r Protein StringDB, eval = FALSE}
@@ -1412,7 +1413,7 @@ dl_stringdbs(
 )
 ```
 
-### 2.9 Missing value imputation 
+### 2.11 Missing value imputation 
 Imputation of peptide and protein data are handle with `pepImp` and `prnImp`. More information can be found from [`mice`](https://cran.r-project.org/web/packages/mice/mice.pdf) and `?prnImp`.  
 
 


### PR DESCRIPTION
Bug fixes:
  - In finding the type of protein accessions, excluded common contaminant proteins before the assessment.

Updates:
  - In PCA plots via `pepPCA` and `prnPCA`, supported additional arguments from `stats::prcomp`.
  - added README `Section 2.2 PCA`.