### PR TITLE
Qz 20190930

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ inst/doc
 git
 blogdown
 public
+R/Copy
+R/New folder
+R/temp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proteoQ
 Title: Data Processing and Informatic Analysis of  Spectrometrirc Data
-Version: 1.2.3.1
+Version: 1.2.4.0
 Authors@R: 
     person(given = "Qiang",
            family = "Zhang",

--- a/R/corrplots.R
+++ b/R/corrplots.R
@@ -58,6 +58,8 @@ plotCorr <- function (df = NULL, id, anal_type, data_select, col_select = NULL, 
 	  stop("`data_select` nees to be either`logFC` or `logInt`.", call. = FALSE)
 	}
 	
+	label_scheme_sub <- label_scheme_sub %>% dplyr::filter(Sample_ID %in% colnames(df))
+	
 	if (is.null(width)) width <- 1.4 * length(label_scheme_sub$Sample_ID)
 	if (is.null(height)) height <- width
 	if (ncol(df) > 44) stop("Maximal number of samples for correlation plots is 44.", call. = FALSE)
@@ -328,6 +330,8 @@ plot_corr_sub <- function (df, xlab, ylab, filename, filepath,
 
   quietly_log <- purrr::quietly(ggsave)(file.path(filepath, gg_imgname(filename)), 
                                         plot = p1, width = width, height = height, dpi = dpi, units = "in")
+  
+  invisible(p2$data)
 }
 
 

--- a/R/depreciated.R
+++ b/R/depreciated.R
@@ -11,7 +11,7 @@
 #'@seealso \code{\link{anal_prnString}} for protein-protein interaction
 #'  networks.
 #'@export
-dl_stringdbs <- function(species = "human", db_path = "~\\proteoQ\\dbs\\string", overwrite = FALSE) {
+dl_stringdbs <- function(species = "human", db_path = "~/proteoQ/dbs/string", overwrite = FALSE) {
   species <- rlang::as_string(rlang::enexpr(species))
   db_path <- create_db_path(db_path)
   

--- a/R/go.R
+++ b/R/go.R
@@ -255,7 +255,7 @@ set_db_outname <- function(filename = NULL, species = "human", signature) {
 #' 
 #' @inheritParams prepMSig
 dl_msig <- function(msig_url = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/c2.all.v7.0.entrez.gmt", 
-                    db_path = "~\\proteoQ\\dbs\\msig", overwrite = FALSE) {
+                    db_path = "~/proteoQ/dbs/msig", overwrite = FALSE) {
   
   if (!grepl("\\.entrez\\.gmt$", msig_url)) {
     stop("Use a link to a `.entrez.gmt` file; not `.symbols.gmt`.", call. = FALSE)
@@ -343,7 +343,7 @@ proc_gmt <- function(species, abbr_species, ortho_mart, fn_gmt, db_path, filenam
 #'  Signatures}, the argument is further applied to differentiate the same
 #'  biological terms under different species.
 #'@param db_path Character string; the local path for database(s). The default
-#'  is \code{"~\\proteoQ\\dbs\\go"}.
+#'  is \code{"~/proteoQ/dbs/go"}.
 #'@param gaf_url A URL to
 #'  \href{http://current.geneontology.org/products/pages/downloads.html}{GO
 #'  Annotation File} (GAF). A valid web address is required for species other
@@ -372,8 +372,8 @@ proc_gmt <- function(species, abbr_species, ortho_mart, fn_gmt, db_path, filenam
 #' prepGO(human)
 #' prepGO(mouse)
 #' 
-#' # head(readRDS(file.path("~\\proteoQ\\dbs\\go\\go_hs.rds")))
-#' # head(readRDS(file.path("~\\proteoQ\\dbs\\go\\go_mm.rds")))
+#' # head(readRDS(file.path("~/proteoQ/dbs/go/go_hs.rds")))
+#' # head(readRDS(file.path("~/proteoQ/dbs/go/go_mm.rds")))
 #'
 #' # `mouse` with a slim OBO
 #' prepGO(
@@ -400,13 +400,13 @@ proc_gmt <- function(species, abbr_species, ortho_mart, fn_gmt, db_path, filenam
 #' \dontrun{
 #' # enrichment analysis with custom `GO`
 #' prnGSPA(
-#'   gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-#'                "~\\proteoQ\\dbs\\go\\go_mm.rds"),
+#'   gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+#'                "~/proteoQ/dbs/go/go_mm.rds"),
 #' )
 #' }
 #'@export
 prepGO <- function(species = "human", abbr_species = NULL, gaf_url = NULL, obo_url = NULL, 
-                   db_path = "~\\proteoQ\\dbs\\go", 
+                   db_path = "~/proteoQ/dbs/go", 
                    type = c("biological_process", "cellular_component", "molecular_function"), 
                    filename = NULL, overwrite = FALSE) {
   
@@ -506,7 +506,7 @@ prepGO <- function(species = "human", abbr_species = NULL, gaf_url = NULL, obo_u
 #'  for other species; instead, users will provide values under arguments
 #'  \code{ortho_mart} for the lookup of orthologs to human.
 #'@param db_path Character string; the local path for database(s). The default
-#'  is \code{"~\\proteoQ\\dbs\\msig"}.
+#'  is \code{"~/proteoQ/dbs/msig"}.
 #'@param msig_url A URL to
 #'  \href{https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/}{MSig
 #'  }. At the \code{NULL} default, a \code{c2.all.v[...].entrez.gmt} data will
@@ -529,15 +529,15 @@ prepGO <- function(species = "human", abbr_species = NULL, gaf_url = NULL, obo_u
 #' ## the default `MSig` is `c2.all`
 #' # `human`; outputs under `db_path`
 #' prepMSig()
-#' head(readRDS(file.path("~\\proteoQ\\dbs\\msig\\msig_hs.rds")))
+#' head(readRDS(file.path("~/proteoQ/dbs/msig/msig_hs.rds")))
 #'
 #' # `mouse`
 #' prepMSig(species = mouse, filename = msig_mm.rds)
-#' head(readRDS(file.path("~\\proteoQ\\dbs\\msig\\msig_mm.rds")))
+#' head(readRDS(file.path("~/proteoQ/dbs/msig/msig_mm.rds")))
 #'
 #' # `rat`
 #' prepMSig(species = rat, filename = msig_rn.rds)
-#' head(readRDS(file.path("~\\proteoQ\\dbs\\msig\\msig_rn.rds")))
+#' head(readRDS(file.path("~/proteoQ/dbs/msig/msig_rn.rds")))
 #'
 #' # `dog`; need `ortho_mart` for species other than `human`, `mouse` and `rat`
 #' # (try `?biomaRt::useMart` for a list of marts)
@@ -556,8 +556,8 @@ prepGO <- function(species = "human", abbr_species = NULL, gaf_url = NULL, obo_u
 #'   filename = msig_cf2.rds,
 #' )
 #'
-#' msig_cf <- readRDS(file.path("~\\proteoQ\\dbs\\msig\\msig_cf.rds"))
-#' msig_cf2 <- readRDS(file.path("~\\proteoQ\\dbs\\msig\\msig_cf2.rds"))
+#' msig_cf <- readRDS(file.path("~/proteoQ/dbs/msig/msig_cf.rds"))
+#' msig_cf2 <- readRDS(file.path("~/proteoQ/dbs/msig/msig_cf2.rds"))
 #'identical(msig_cf, msig_cf2)
 #'
 #' ## use an `MSig`other than the default of `c2.all`
@@ -578,8 +578,8 @@ prepGO <- function(species = "human", abbr_species = NULL, gaf_url = NULL, obo_u
 #' \dontrun{
 #' # enrichment analysis with custom `MSig`
 #' prnGSPA(
-#'   gset_nms = c("~\\proteoQ\\dbs\\msig\\msig_hs.rds",
-#'                "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+#'   gset_nms = c("~/proteoQ/dbs/msig/msig_hs.rds",
+#'                "~/proteoQ/dbs/msig/msig_mm.rds"),
 #' )
 #' }
 #'
@@ -590,7 +590,7 @@ prepMSig <- function(species = "human", msig_url = NULL, abbr_species = NULL,
                                          rat = "rnorvegicus_gene_ensembl", 
                                          human = "to_itself",
                                          "unknown"), 
-                     db_path = "~\\proteoQ\\dbs\\msig", filename = NULL, overwrite = FALSE) {
+                     db_path = "~/proteoQ/dbs/msig", filename = NULL, overwrite = FALSE) {
 
   old_opts <- options()
   options(warn = 1)
@@ -643,7 +643,7 @@ prepMSig <- function(species = "human", msig_url = NULL, abbr_species = NULL,
 #'   org.Rn.eg.db
 #' @export
 map_to_entrez <- function(species = "human", abbr_species = NULL, from = "UNIPROT", 
-                          filename = NULL, db_path = "~\\proteoQ\\dbs\\entrez", overwrite = FALSE) {
+                          filename = NULL, db_path = "~/proteoQ/dbs/entrez", overwrite = FALSE) {
   old_opts <- options()
   options(warn = 1)
   on.exit(options(old_opts), add = TRUE)
@@ -719,13 +719,13 @@ map_to_entrez <- function(species = "human", abbr_species = NULL, from = "UNIPRO
 #'
 #'@param species Character string; the name of a species. 
 #'@param db_path Character string; the local path for database(s). The default
-#'  is \code{"~\\proteoQ\\dbs\\entrez"}.
+#'  is \code{"~/proteoQ/dbs/entrez"}.
 #'@inheritParams prepMSig
 #'@import dplyr purrr tidyr plyr reshape2 org.Hs.eg.db org.Mm.eg.db org.Rn.eg.db
 #'@example inst/extdata/examples/prepEntrez_.R
 #'@export
 Uni2Entrez <- function(species = "human", abbr_species = NULL, filename = NULL, 
-                       db_path = "~\\proteoQ\\dbs\\entrez", overwrite = FALSE) {
+                       db_path = "~/proteoQ/dbs/entrez", overwrite = FALSE) {
   map_to_entrez(!!rlang::enexpr(species), 
                 !!rlang::enexpr(abbr_species), 
                 "UNIPROT", 
@@ -752,7 +752,7 @@ Uni2Entrez <- function(species = "human", abbr_species = NULL, filename = NULL,
 #'@example inst/extdata/examples/prepEntrez_.R
 #'@export
 Ref2Entrez <- function(species = "human", abbr_species = NULL, filename = NULL, 
-                       db_path = "~\\proteoQ\\dbs\\entrez", overwrite = FALSE) {
+                       db_path = "~/proteoQ/dbs/entrez", overwrite = FALSE) {
   map_to_entrez(!!rlang::enexpr(species), 
                 !!rlang::enexpr(abbr_species), 
                 "REFSEQ", 
@@ -774,7 +774,7 @@ Ref2Entrez <- function(species = "human", abbr_species = NULL, filename = NULL,
 map_to_entrez_os_name <- function(species = "human", abbr_species = NULL, 
                                   os_name = "Homo sapiens", 
                                   from = "UNIPROT", 
-                                  filename = NULL, db_path = "~\\proteoQ\\dbs\\entrez", overwrite = FALSE) {
+                                  filename = NULL, db_path = "~/proteoQ/dbs/entrez", overwrite = FALSE) {
   # the value of species will be used under column `species` in Protein.txt etc
   # add column species in the rds output
   

--- a/R/gsea.R
+++ b/R/gsea.R
@@ -182,7 +182,7 @@ prnGSEA <- function (gset_nms = "go_sets",
   
   check_dots(c("id", "anal_type", "df2"), ...)
 
-  dir.create(file.path(dat_dir, "Protein\\GSEA\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/GSEA/log"), recursive = TRUE, showWarnings = FALSE)
 
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)

--- a/R/gspa.R
+++ b/R/gspa.R
@@ -90,10 +90,10 @@
 #'  the formula(s) will match those used in \code{\link{pepSig}} or
 #'  \code{\link{prnSig}}.
 #'@param ... \code{filter_}: Logical expression(s) for the row filtration
-#'  against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+#'  against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 #'  See also \code{\link{normPSM}} for the format of \code{filter_} statements.
 #'  \cr \cr \code{arrange_}: Variable argument statements for the row ordering
-#'  against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+#'  against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 #'  See also \code{\link{prnHM}} for the format of \code{arrange_} statements.
 #'@import dplyr rlang ggplot2 networkD3
 #'@importFrom magrittr %>%
@@ -188,7 +188,7 @@ prnGSPA <- function (gset_nms = c("go_sets", "c2_msig"), method = "mean",
   check_dots(c("id", "anal_type", "var_cutoff"), ...)
   check_gset_nms(gset_nms)
   
-  dir.create(file.path(dat_dir, "Protein\\GSPA\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/GSPA/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)
@@ -950,7 +950,7 @@ prnGSPAHM <- function (scale_log2r = TRUE, complete_cases = FALSE, impute_na = F
                        annot_cols = NULL, annot_colnames = NULL, annot_rows = NULL, 
                        df2 = NULL, filename = NULL, ...) {
   check_dots(c("id", "anal_type", "df", "filepath"), ...)
-  dir.create(file.path(dat_dir, "Protein\\GSPA\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/GSPA/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)

--- a/R/gsva.R
+++ b/R/gsva.R
@@ -23,7 +23,7 @@
 #'  absolute log2FC smaller than the threshold will be removed from multiple
 #'  test corrections. The default is at log2(1.1).
 #'@param ... \code{filter_}: Logical expression(s) for the row filtration
-#'  against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+#'  against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 #'  See also \code{\link{normPSM}} for the format of \code{filter_} statements.
 #'  \cr \cr \code{arrange_}: Variable argument statements for the row ordering
 #'  against data in a primary file linked to \code{df}. See also
@@ -121,7 +121,7 @@ prnGSVA <- function (gset_nms = c("go_sets", "c2_msig"),
   if (any(names(rlang::enexprs(...)) %in% c("expr", "gset.idx.list", "annotation"))) 
     stop(err_msg1, call. = FALSE)
 
-  dir.create(file.path(dat_dir, "Protein\\GSVA\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/GSVA/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)
@@ -138,7 +138,7 @@ prnGSVA <- function (gset_nms = c("go_sets", "c2_msig"),
 	dots <- dots[!names(dots) %in% names(fmls)]
 
 	if (rlang::is_empty(fmls)) {
-	  fml_file <-  file.path(dat_dir, "Calls\\prnSig_formulas.rda")
+	  fml_file <-  file.path(dat_dir, "Calls/prnSig_formulas.rda")
 	  if (file.exists(fml_file)) {
 	    load(file = fml_file)
 	    dots <- c(dots, prnSig_formulas)
@@ -227,7 +227,7 @@ gsvaTest <- function(df = NULL, id = "entrez", label_scheme_sub = NULL,
       var_cutoff, pval_cutoff, logFC_cutoff
     )) 
   
-  out_path <- file.path(dat_dir, "Protein\\GSVA\\log\\prnGSVA_log.txt")
+  out_path <- file.path(dat_dir, "Protein/GSVA/log/prnGSVA_log.txt")
   
   purrr::map(quietly_log, ~ {
     .x[[1]] <- NULL

--- a/R/hm.R
+++ b/R/hm.R
@@ -257,6 +257,7 @@ plotHM <- function(df, id, col_benchmark, label_scheme_sub, filepath, filename,
                         "clustering_method", 
                         "color", "annotation_colors", "breaks")]
   
+  # references under expt_smry::Sample_ID may be included
   p <- my_pheatmap(
     mat = df_hm,
     filename = file.path(filepath, filename),

--- a/R/informatics.R
+++ b/R/informatics.R
@@ -654,13 +654,13 @@ find_pri_df <- function (anal_type = "Model", df = NULL, id = "gene", impute_na 
 
   if (is.null(df)) {
     if (id %in% c("pep_seq", "pep_seq_mod")) {
-      fn_p <- file.path(dat_dir, "Peptide\\Model", "Peptide_pVals.txt")
-      fn_imp_p <- file.path(dat_dir, "Peptide\\Model", "Peptide_impNA_pVals.txt")
+      fn_p <- file.path(dat_dir, "Peptide/Model", "Peptide_pVals.txt")
+      fn_imp_p <- file.path(dat_dir, "Peptide/Model", "Peptide_impNA_pVals.txt")
       fn_raw <- file.path(dat_dir, "Peptide", "Peptide.txt")
       fn_imp <- file.path(dat_dir, "Peptide", "Peptide_impNA.txt")
     } else if (id %in% c("prot_acc", "gene")) {
-      fn_p <- file.path(dat_dir, "Protein\\Model", "Protein_pVals.txt")
-      fn_imp_p <- file.path(dat_dir, "Protein\\Model", "Protein_impNA_pVals.txt")
+      fn_p <- file.path(dat_dir, "Protein/Model", "Protein_pVals.txt")
+      fn_imp_p <- file.path(dat_dir, "Protein/Model", "Protein_impNA_pVals.txt")
       fn_raw <- file.path(dat_dir, "Protein", "Protein.txt")
       fn_imp <- file.path(dat_dir, "Protein", "Protein_impNA.txt")
     } else {
@@ -721,10 +721,10 @@ find_pri_df <- function (anal_type = "Model", df = NULL, id = "gene", impute_na 
     if (anal_type == "Model") stop("Use default file name.", call. = FALSE)
     
     if (id %in% c("pep_seq", "pep_seq_mod")) {
-      src_path <- file.path(dat_dir, "Peptide\\Model", df)
+      src_path <- file.path(dat_dir, "Peptide/Model", df)
       if (!file.exists(src_path)) src_path <- file.path(dat_dir, "Peptide", df)
     } else if (id %in% c("prot_acc", "gene")) {
-      src_path <- file.path(dat_dir, "Protein\\Model", df)
+      src_path <- file.path(dat_dir, "Protein/Model", df)
       if (!file.exists(src_path)) src_path <- file.path(dat_dir, "Protein", df)
     }
   }
@@ -736,7 +736,7 @@ find_pri_df <- function (anal_type = "Model", df = NULL, id = "gene", impute_na 
   
   df <- df %>% reorderCols2()
 
-  message(paste("Primary file loaded:", gsub("\\\\", "/", src_path)))
+  message(paste("Primary file loaded:", src_path))
   
   return(df)
 }

--- a/R/nmf.R
+++ b/R/nmf.R
@@ -173,9 +173,9 @@ plotNMFCon <- function(id, rank, label_scheme_sub, scale_log2r, complete_cases, 
     D_matrix <- res_nmf@consensus
 
     if (!is.null(dim(D_matrix))) {
-      message(paste("File loaded:", gsub("\\\\", "/", file.path(filepath, .x))))
+      message(paste("File loaded:", file.path(filepath, .x)))
     } else {
-      stop(paste("Non-existed file or directory:", gsub("\\\\", "/", file.path(filepath, .x))))
+      stop(paste("Non-existed file or directory:", file.path(filepath, .x)))
     }
 
     rank <- gsub(".*_rank(\\d+)[^\\d]*\\.rda$", "\\1", .x) %>% as.numeric()
@@ -389,9 +389,9 @@ plotNMFCoef <- function(id, rank, label_scheme_sub, scale_log2r, complete_cases,
     D_matrix <- coef(res_nmf)
     
     if (!is.null(dim(D_matrix))) {
-      message(paste("File loaded:", gsub("\\\\", "/", file.path(filepath, .x))))
+      message(paste("File loaded:", file.path(filepath, .x)))
     } else {
-      stop(paste("Non-existed file or directory:", gsub("\\\\", "/", file.path(filepath, .x))))
+      stop(paste("Non-existed file or directory:", file.path(filepath, .x)), call. = FALSE)
     }
 
     rank <- gsub(".*_rank(\\d+)[^\\d]*\\.rda$", "\\1", .x) %>% as.numeric()
@@ -810,7 +810,7 @@ anal_pepNMF <- function (col_select = NULL, col_group = NULL,
   
   check_dots(c("id", "df2", "anal_type"), ...)
   
-  dir.create(file.path(dat_dir, "Peptide\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/NMF/log"), recursive = TRUE, showWarnings = FALSE)
 
   id <- match_call_arg(normPSM, group_psm_by)
   stopifnot(rlang::as_string(id) %in% c("pep_seq", "pep_seq_mod"), length(id) == 1)
@@ -855,7 +855,7 @@ anal_prnNMF <- function (col_select = NULL, col_group = NULL,
   
   check_dots(c("id", "df2", "anal_type"), ...)
   
-  dir.create(file.path(dat_dir, "Protein\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/NMF/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)
@@ -979,7 +979,7 @@ plot_pepNMFCon <- function (col_select = NULL,
                             annot_cols = NULL, annot_colnames = NULL, rank = NULL, ...) {
   check_dots(c("id", "anal_type", "df", "col_group", "filepath"), ...)
 
-  dir.create(file.path(dat_dir, "Peptide\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/NMF/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_psm_by)
   stopifnot(rlang::as_string(id) %in% c("pep_seq", "pep_seq_mod"), length(id) == 1)  
@@ -1016,7 +1016,7 @@ plot_prnNMFCon <- function (col_select = NULL,
                             annot_cols = NULL, annot_colnames = NULL, rank = NULL, ...) {
   check_dots(c("id", "anal_type", "df", "col_group", "filepath"), ...)
   
-  dir.create(file.path(dat_dir, "Protein\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/NMF/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)  
@@ -1053,7 +1053,7 @@ plot_pepNMFCoef <- function (col_select = NULL,
                              annot_cols = NULL, annot_colnames = NULL, rank = NULL, ...) {
   check_dots(c("id", "anal_type", "df", "col_group", "filepath"), ...)
   
-  dir.create(file.path(dat_dir, "Peptide\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/NMF/log"), recursive = TRUE, showWarnings = FALSE)
 
   id <- match_call_arg(normPSM, group_psm_by)
   stopifnot(rlang::as_string(id) %in% c("pep_seq", "pep_seq_mod"), length(id) == 1)  
@@ -1090,7 +1090,7 @@ plot_prnNMFCoef <- function (col_select = NULL,
                              annot_cols = NULL, annot_colnames = NULL, rank = NULL, ...) {
   check_dots(c("id", "anal_type", "df", "col_group", "filepath"), ...)
   
-  dir.create(file.path(dat_dir, "Protein\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/NMF/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)
@@ -1205,7 +1205,7 @@ plot_metaNMF <- function (col_select = NULL,
                           rank = NULL, annot_cols = NULL, annot_colnames = NULL, ...) {
   check_dots(c("id", "anal_type", "col_group"), ...)
   
-  dir.create(file.path(dat_dir, "Protein\\NMF\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/NMF/log"), recursive = TRUE, showWarnings = FALSE)
   
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)  

--- a/R/nmf.R
+++ b/R/nmf.R
@@ -29,6 +29,8 @@ analNMF <- function(df, id, rank, nrun, seed, col_group, label_scheme_sub,
     prepDM(id = !!id, scale_log2r = scale_log2r, 
            sub_grp = label_scheme_sub$Sample_ID, anal_type = anal_type) %>% 
     .$log2R
+  
+  label_scheme_sub <- label_scheme_sub %>% dplyr::filter(Sample_ID %in% colnames(df))
 
   col_group <- rlang::enexpr(col_group) # optional phenotypic information
 

--- a/R/normalization.R
+++ b/R/normalization.R
@@ -158,9 +158,9 @@ normMulGau <- function(df, method_align, n_comp, seed = NULL, range_log2r, range
   
   # add mean-deviation info for `expt_smry::Select`ed samples
   add_mean_dev <- function (df, label_scheme_fit) {
-    if (grepl("Peptide\\\\", filepath)) {
+    if (grepl("Peptide\\\\", filepath) || grepl("Peptide/", filepath)) {
       prefix <- "pep_mean_"
-    } else if (grepl("Protein\\\\", filepath)) {
+    } else if (grepl("Protein\\\\", filepath) || grepl("Protein/", filepath)) {
       prefix <- "prot_mean_"
     } else {
       return(df)
@@ -300,8 +300,8 @@ normMulGau <- function(df, method_align, n_comp, seed = NULL, range_log2r, range
       run_scripts <- FALSE
       if (run_scripts) {
         if (anyNA(params$Sample_ID)) {
-          try(unlink(file.path(dat_dir, "Peptide\\Histogram\\MGKernel_params_[NZ].txt")))
-          try(unlink(file.path(dat_dir, "Protein\\Histogram\\MGKernel_params_[NZ].txt")))
+          try(unlink(file.path(dat_dir, "Peptide/Histogram/MGKernel_params_[NZ].txt")))
+          try(unlink(file.path(dat_dir, "Protein/Histogram/MGKernel_params_[NZ].txt")))
   
           missing_samples <- local({
             par_samples <- params$Sample_ID %>% unique() %>% .[!is.na(.)]

--- a/R/peptable.R
+++ b/R/peptable.R
@@ -175,7 +175,7 @@ normPep_Mplex <- function (group_psm_by = "pep_seq_mod", group_pep_by = "prot_ac
     n_comp = 1L,
     range_log2r = c(0, 100),
     range_int = c(0, 100),
-    filepath = file.path(dat_dir, "Peptide\\Histogram"),
+    filepath = file.path(dat_dir, "Peptide/Histogram"),
     col_select = rlang::expr(Sample_ID), 
   )
 }
@@ -275,8 +275,8 @@ load_prior <- function(filename, id) {
     dplyr::filter(rowSums(!is.na( .[grep("^log2_R[0-9]{3}", names(.))] )) > 0) 
   
   if (! id %in% names(df)) {
-    try(unlink(file.path(dat_dir, "Peptide\\Peptide.txt")))
-    try(unlink(file.path(dat_dir, "Protein\\Protein.txt")))
+    try(unlink(file.path(dat_dir, "Peptide/Peptide.txt")))
+    try(unlink(file.path(dat_dir, "Protein/Protein.txt")))
     stop("`Peptide.txt` deleted as column `", id, "` not available.", call. = FALSE)
   }
   
@@ -414,7 +414,7 @@ fmt_num_cols <- function (df) {
 #'  system.file("extdata", "maxquant_peptide_keys.txt", package = "proteoQ") \cr
 #'  system.file("extdata", "maxquant_protein_keys.txt", package = "proteoQ") \cr
 #'  
-#'@return The primary output is in \code{...\\Peptide\\Peptide.txt}.
+#'@return The primary output is in \code{.../Peptide/Peptide.txt}.
 #'
 #'@example inst/extdata/examples/mergePep_.R
 #'@import stringr dplyr tidyr purrr data.table rlang
@@ -423,11 +423,11 @@ fmt_num_cols <- function (df) {
 #'@importFrom plyr ddply
 #'@export
 mergePep <- function (plot_log2FC_cv = TRUE, use_duppeps = TRUE, ...) {
-  dir.create(file.path(dat_dir, "Peptide\\cache"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Peptide\\Histogram"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Peptide\\log2FC_cv\\raw"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Peptide\\log2FC_cv\\purged"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Peptide\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/Histogram"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/log2FC_cv/raw"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/log2FC_cv/purged"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/log"), recursive = TRUE, showWarnings = FALSE)
   
   old_opts <- options()
   options(warn = 1)
@@ -443,7 +443,7 @@ mergePep <- function (plot_log2FC_cv = TRUE, use_duppeps = TRUE, ...) {
   
   group_psm_by <- match_call_arg(normPSM, group_psm_by)
   group_pep_by <- match_call_arg(normPSM, group_pep_by)
-  filename <- file.path(dat_dir, "Peptide\\Peptide.txt")
+  filename <- file.path(dat_dir, "Peptide/Peptide.txt")
   
   dots <- rlang::enexprs(...)
   filter_dots <- dots %>% .[purrr::map_lgl(., is.language)] %>% .[grepl("^filter_", names(.))]
@@ -457,7 +457,7 @@ mergePep <- function (plot_log2FC_cv = TRUE, use_duppeps = TRUE, ...) {
     quiet_out <- purrr::quietly(sd_violin)(
       df = df, 
       id = !!group_pep_by, 
-      filepath = file.path(dat_dir, "Peptide\\log2FC_cv\\raw\\Peptide_sd.png"), 
+      filepath = file.path(dat_dir, "Peptide/log2FC_cv/raw/Peptide_sd.png"), 
       width = 8 * n_TMT_sets(label_scheme), 
       height = 8, 
       type = "log2_R", 
@@ -609,7 +609,7 @@ mergePep <- function (plot_log2FC_cv = TRUE, use_duppeps = TRUE, ...) {
 #'  system.file("extdata", "maxquant_peptide_keys.txt", package = "proteoQ") \cr
 #'  system.file("extdata", "maxquant_protein_keys.txt", package = "proteoQ") \cr
 #'
-#'@return The primary output is in \code{...\\Peptide\\Peptide.txt}.
+#'@return The primary output is in \code{.../Peptide/Peptide.txt}.
 #'
 #'@example inst/extdata/examples/normPep_.R
 #'
@@ -631,9 +631,9 @@ standPep <- function (method_align = c("MC", "MGKernel"), col_select = NULL, ran
   load(file = file.path(dat_dir, "label_scheme_full.rda"))
   load(file = file.path(dat_dir, "label_scheme.rda"))
   
-  ok_existing_params(file.path(dat_dir, "Peptide\\Histogram\\MGKernel_params_N.txt"))
+  ok_existing_params(file.path(dat_dir, "Peptide/Histogram/MGKernel_params_N.txt"))
 
-  filename <- file.path(dat_dir, "Peptide\\Peptide.txt")
+  filename <- file.path(dat_dir, "Peptide/Peptide.txt")
   if (!file.exists(filename)) stop(filename, " not found; run `mergePep(...)` first", call. = FALSE)
   
   id <- match_call_arg(normPSM, group_psm_by)
@@ -688,7 +688,7 @@ standPep <- function (method_align = c("MC", "MGKernel"), col_select = NULL, ran
       seed = seed,
       range_log2r = range_log2r,
       range_int = range_int,
-      filepath = file.path(dat_dir, "Peptide\\Histogram"),
+      filepath = file.path(dat_dir, "Peptide/Histogram"),
       col_select = col_select, 
       !!!dots, 
     ) %>% 
@@ -698,7 +698,7 @@ standPep <- function (method_align = c("MC", "MGKernel"), col_select = NULL, ran
 
   if (plot_log2FC_cv & TMT_plex(label_scheme) > 0) {
     sd_violin(df = df, id = !!group_pep_by, 
-              filepath = file.path(dat_dir, "Peptide\\log2FC_cv\\raw", "Peptide_sd.png"), 
+              filepath = file.path(dat_dir, "Peptide/log2FC_cv/raw", "Peptide_sd.png"), 
               width = 8 * n_TMT_sets(label_scheme), height = 8, 
               type = "log2_R", adjSD = FALSE, is_psm = FALSE)
   }
@@ -798,7 +798,7 @@ standPep <- function (method_align = c("MC", "MGKernel"), col_select = NULL, ran
 #'  system.file("extdata", "maxquant_peptide_keys.txt", package = "proteoQ") \cr
 #'  system.file("extdata", "maxquant_protein_keys.txt", package = "proteoQ") \cr
 #'  
-#'@return The primary output in "\code{...\\Protein\\Protein.txt}".
+#'@return The primary output in "\code{.../Protein/Protein.txt}".
 #'
 #'@example inst/extdata/examples/Pep2Prn_.R
 #'@import stringr dplyr purrr rlang  magrittr
@@ -806,9 +806,9 @@ standPep <- function (method_align = c("MC", "MGKernel"), col_select = NULL, ran
 Pep2Prn <- function (method_pep_prn = c("median", "mean", "weighted.mean", "top.3"), 
                      use_unique_pep = TRUE, ...) {
   
-  dir.create(file.path(dat_dir, "Protein\\Histogram"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Protein\\cache"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Protein\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/Histogram"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/log"), recursive = TRUE, showWarnings = FALSE)
   
   old_opts <- options()
   options(warn = 1)
@@ -853,7 +853,7 @@ Pep2Prn <- function (method_pep_prn = c("median", "mean", "weighted.mean", "top.
     n_comp = 1L,
     range_log2r = c(0, 100),
     range_int = c(0, 100),
-    filepath = file.path(dat_dir, "Protein\\Histogram"),
+    filepath = file.path(dat_dir, "Protein/Histogram"),
     col_select = rlang::expr(Sample_ID), 
   ) 
   
@@ -863,7 +863,7 @@ Pep2Prn <- function (method_pep_prn = c("median", "mean", "weighted.mean", "top.
     dplyr::mutate_at(vars(grep("I[0-9]{3}[NC]*", names(.))), ~ round(.x, digits = 0)) %>% 
     dplyr::mutate_at(vars(grep("log2_R[0-9]{3}[NC]*", names(.))), as.numeric) %>% 
     dplyr::mutate_at(vars(grep("log2_R[0-9]{3}[NC]*", names(.))), ~ round(.x, digits = 3)) %T>% 
-    write.table(., file.path(dat_dir, "Protein\\Protein.txt"), sep = "\t", col.names = TRUE, row.names = FALSE)
+    write.table(., file.path(dat_dir, "Protein/Protein.txt"), sep = "\t", col.names = TRUE, row.names = FALSE)
 }
 
 
@@ -884,7 +884,7 @@ pep_to_prn <- function(id, method_pep_prn, use_unique_pep, gn_rollup, ...) {
   stopifnot(file.exists(fn_fasta))
   fasta <- seqinr::read.fasta(fn_fasta, seqtype = "AA", as.string = TRUE, set.attributes = TRUE)
   
-  df <- read.csv(file.path(dat_dir, "Peptide\\Peptide.txt"), check.names = FALSE, 
+  df <- read.csv(file.path(dat_dir, "Peptide/Peptide.txt"), check.names = FALSE, 
                  header = TRUE, sep = "\t", comment.char = "#") %>% 
     dplyr::filter(rowSums(!is.na( .[grep("^log2_R[0-9]{3}", names(.))] )) > 0)
   
@@ -1070,11 +1070,11 @@ assign_duppeps <- function(df, group_psm_by, group_pep_by, use_duppeps = TRUE) {
         dplyr::filter(N > 1)
       
       if (nrow(dup_peps_af) > 0) {
-        write.csv(dup_peps_af, file.path(dat_dir, "Peptide\\dbl_dipping_peptides.csv"), row.names = FALSE)
+        write.csv(dup_peps_af, file.path(dat_dir, "Peptide/dbl_dipping_peptides.csv"), row.names = FALSE)
         df <- df %>% dplyr::filter(! (!!rlang::sym(group_psm_by) %in% dup_peps_af[[group_psm_by]]))
       }
     } else {
-      write.csv(dup_peps, file.path(dat_dir, "Peptide\\dbl_dipping_peptides.csv"), row.names = FALSE)
+      write.csv(dup_peps, file.path(dat_dir, "Peptide/dbl_dipping_peptides.csv"), row.names = FALSE)
       df <- df %>% dplyr::filter(! (!!rlang::sym(group_psm_by) %in% dup_peps[[group_psm_by]]))
     }
   }

--- a/R/peptable.R
+++ b/R/peptable.R
@@ -11,11 +11,11 @@ newColnames <- function(i, x, label_scheme) {
   label_scheme_sub <- label_scheme %>%
     dplyr::filter(TMT_Set == i)
   
-  cols <- grep(paste0("[RI][0-9]{3}[NC]*_", i, "$"), names(x))
-  nm_channel <- gsub(paste0("([RI][0-9]{3}[NC]*)_", i, "$"), "\\1", names(x)[cols])
+  cols <- grep(paste0("[RI][0-9]{3}[NC]{0,1}_", i, "$"), names(x))
+  nm_channel <- gsub(paste0("([RI][0-9]{3}[NC]{0,1})_", i, "$"), "\\1", names(x)[cols])
   names(x)[cols] <- paste0(nm_channel, " (", as.character(label_scheme_sub$Sample_ID), ")")
   
-  cols <- grep("[RI][0-9]{3}.*\\s+\\(.*\\)$", names(x))
+  cols <- grep("[RI][0-9]{3}[NC]{0,1}\\s+\\(.*\\)$", names(x))
   
   # cols with new names go first
   if (length(cols) < ncol(x)) x <- dplyr::bind_cols(x[, cols], x[, -cols, drop = FALSE])
@@ -86,7 +86,12 @@ normPep_Mplex <- function (group_psm_by = "pep_seq_mod", group_pep_by = "prot_ac
       tidyr::spread(ID, value)
     rm(Levels)
     
-    for (set_idx in seq_len(n_TMT_sets(label_scheme))) {
+    set_indexes <- gsub("^.*TMTset(\\d+).*", "\\1", filelist) %>% 
+      unique() %>% 
+      as.integer() %>% 
+      sort()
+    
+    for (set_idx in set_indexes) {
       df_num <- newColnames(set_idx, df_num, label_scheme)
     }
     

--- a/R/prntable.R
+++ b/R/prntable.R
@@ -101,7 +101,7 @@
 #'  system.file("extdata", "maxquant_peptide_keys.txt", package = "proteoQ") \cr
 #'  system.file("extdata", "maxquant_protein_keys.txt", package = "proteoQ") \cr
 #'
-#'@return The primary output is in \code{...\\Protein\\Protein.txt}.
+#'@return The primary output is in \code{.../Protein/Protein.txt}.
 #'
 #'@example inst/extdata/examples/normPrn_.R
 #'@import stringr dplyr tidyr purrr data.table rlang
@@ -113,9 +113,9 @@ standPrn <- function (method_align = c("MC", "MGKernel"),
                     range_log2r = c(10, 90), range_int = c(5, 95), n_comp = NULL, seed = NULL, 
                     col_select = NULL, cache = TRUE, ...) {
   
-  dir.create(file.path(dat_dir, "Protein\\Histogram"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Protein\\cache"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "Protein\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/Histogram"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/log"), recursive = TRUE, showWarnings = FALSE)
   
   old_opts <- options()
   on.exit(options(old_opts), add = TRUE)
@@ -154,7 +154,7 @@ standPrn <- function (method_align = c("MC", "MGKernel"),
   col_select <- ifelse(is.null(col_select), rlang::expr(Sample_ID), rlang::sym(col_select))
   load(file = file.path(dat_dir, "label_scheme.rda"))
   
-  ok_existing_params(file.path(dat_dir, "Protein\\Histogram\\MGKernel_params_N.txt"))
+  ok_existing_params(file.path(dat_dir, "Protein/Histogram/MGKernel_params_N.txt"))
   
   if (is.null(label_scheme[[col_select]])) {
     col_select <- rlang::expr(Sample_ID)
@@ -168,7 +168,7 @@ standPrn <- function (method_align = c("MC", "MGKernel"),
   
   dots <- rlang::enexprs(...)
   
-  filename <- file.path(dat_dir, "Protein\\Protein.txt")
+  filename <- file.path(dat_dir, "Protein/Protein.txt")
   
   if (!file.exists(filename)) {
     stop(filename, " not found; run `Pep2Prn` first.")
@@ -186,7 +186,7 @@ standPrn <- function (method_align = c("MC", "MGKernel"),
     seed = seed, 
     range_log2r = range_log2r, 
     range_int = range_int, 
-    filepath = file.path(dat_dir, "Protein\\Histogram"), 
+    filepath = file.path(dat_dir, "Protein/Histogram"), 
     col_select = col_select, 
     !!!dots,
   )

--- a/R/proteoQ.R
+++ b/R/proteoQ.R
@@ -16,7 +16,7 @@
 #'   plot_pepNMFCon, plot_prnNMFCon, plot_pepNMFCoef, plot_prnNMFCoef,
 #'   plot_metaNMF, anal_prnTrend, plot_prnTrend, pepSig, prnSig, pepVol, prnVol,
 #'   prnGSPA, prnGSPAHM, gspaMap, anal_prnString, pepImp, prnImp, prnGSVA,
-#'   prnGSEA
+#'   prnGSEA, cluego
 #'
 #' @docType package
 #' @name proteoQ

--- a/R/psmtable.R
+++ b/R/psmtable.R
@@ -6,8 +6,8 @@
 #' @inheritParams load_expts
 #' @examples
 #' \dontrun{
-#' # Supposed that RAW MS files are stored under "~\my_raw"
-#' extract_raws("~\\my_raw")
+#' # Supposed that RAW MS files are stored under "~/my_raw"
+#' extract_raws("~/my_raw")
 #' }
 #'
 #' @import dplyr purrr
@@ -72,18 +72,18 @@ extract_psm_raws <- function(type = c("mascot", "maxquant", "spectrum_mill"), da
     df[1] <- paste0(df[1], paste(rep(",", TMT_plex * 4 -2), collapse = ''))
     
     output_prefix <- gsub("\\.csv$", "", filelist)
-    writeLines(df, file.path(dat_dir, "PSM\\temp", paste0(output_prefix, "_hdr_rm.csv")))
+    writeLines(df, file.path(dat_dir, "PSM/temp", paste0(output_prefix, "_hdr_rm.csv")))
     
     return(TMT_plex)
   }
     
   find_mascot_psmraws <-function(filelist) {
-    dir.create(file.path(dat_dir, "PSM\\temp"), recursive = TRUE, showWarnings = FALSE)
+    dir.create(file.path(dat_dir, "PSM/temp"), recursive = TRUE, showWarnings = FALSE)
     
     TMT_plex <- purrr::map(filelist, batchPSMheader_2)
 
     purrr::walk2(gsub("\\.csv$", "_hdr_rm.csv", filelist), TMT_plex, ~ {
-      df <- read.delim(file.path(dat_dir, "PSM\\temp", .x), sep = ',', check.names = FALSE, 
+      df <- read.delim(file.path(dat_dir, "PSM/temp", .x), sep = ',', check.names = FALSE, 
                  header = TRUE, stringsAsFactors = FALSE, quote = "\"",fill = TRUE , skip = 0)
       
       TMT_plex <- .y
@@ -134,7 +134,7 @@ extract_psm_raws <- function(type = c("mascot", "maxquant", "spectrum_mill"), da
       }
     })
 
-    unlink(file.path(dat_dir, "PSM\\temp"), recursive = TRUE, force = TRUE)
+    unlink(file.path(dat_dir, "PSM/temp"), recursive = TRUE, force = TRUE)
   } 
   
   find_mq_psmraws <- function(filelist) {
@@ -244,7 +244,7 @@ rmPSMHeaders <- function () {
   		data_header <- data_all[1 : (pep_seq_rows[1] - 1)]
   		data_header <- gsub("\"", "", data_header, fixed = TRUE)
   
-  		write.table(data_header, file.path(dat_dir, "PSM\\cache",
+  		write.table(data_header, file.path(dat_dir, "PSM/cache",
   		            paste0(output_prefix, "_header", ".txt")),
   		            sep = "\t", col.names = FALSE, row.names = FALSE)
 		})
@@ -254,7 +254,7 @@ rmPSMHeaders <- function () {
   		  data_queries <- data_all[pep_seq_rows[2] : length(data_all)]
   		  data_queries <- gsub("\"", "", data_queries, fixed = TRUE)
   		  writeLines(data_queries, 
-  		             file.path(dat_dir, "PSM\\cache", paste0(output_prefix, "_queries.csv")))
+  		             file.path(dat_dir, "PSM/cache", paste0(output_prefix, "_queries.csv")))
   		  prep_queries()
 		  })
 		}
@@ -288,7 +288,7 @@ rmPSMHeaders <- function () {
 		
 		if (TMT_plex > 0) data_psm[1] <- paste0(data_psm[1], paste(rep(",", TMT_plex * 4 -2), collapse = ''))
 		
-		writeLines(data_psm, file.path(dat_dir, "PSM\\cache", paste0(output_prefix, "_hdr_rm.csv")))
+		writeLines(data_psm, file.path(dat_dir, "PSM/cache", paste0(output_prefix, "_hdr_rm.csv")))
 		rm(data_psm)
 	}
 
@@ -302,9 +302,9 @@ prep_queries <- function() {
   prep_queries_sub <- function(filelist, dat_dir) {
     fn_prefix <- gsub("\\.[^.]*$", "", filelist)
     fn_suffix <- gsub("^.*\\.([^.]*)$", "\\1", filelist)
-    filepath <- file.path(dat_dir, "PSM\\cache")
+    filepath <- file.path(dat_dir, "PSM/cache")
   
-    df <- readLines(file.path(dat_dir, "PSM\\cache", filelist))
+    df <- readLines(file.path(dat_dir, "PSM/cache", filelist))
   
     nms <- df[1] %>% stringr::str_split(",") %>% unlist()
     
@@ -385,8 +385,8 @@ prep_queries <- function() {
   
   dat_dir <- get_gl_dat_dir()
   
-  filepath <- file.path(dat_dir, "PSM\\cache")
-  filelist = list.files(path = filepath, pattern = "^F[0-9]+\\_queries.csv$")
+  filepath <- file.path(dat_dir, "PSM/cache")
+  filelist = list.files(path = filepath, pattern = "^F[0-9]+_queries.csv$")
   
   if (length(filelist) > 0) {
     message(paste("Process PSM query files under", filepath))
@@ -403,7 +403,7 @@ add_mod_conf <- function(df, dat_dir) {
   dat_file <- unique(df$dat_file)
   stopifnot(length(dat_file) == 1)
   
-  filepath <- file.path(dat_dir, "PSM\\cache", paste0(dat_file, "_queries_conf.rds"))
+  filepath <- file.path(dat_dir, "PSM/cache", paste0(dat_file, "_queries_conf.rds"))
   
   if (! file.exists(filepath)) return(df)
 
@@ -465,7 +465,7 @@ add_mod_conf <- function(df, dat_dir) {
 #' @importFrom magrittr %T>%
 add_mascot_pepseqmod <- function(df, use_lowercase_aa) {
   dat_id <- df$dat_file %>% unique()
-  dat_file <- file.path(dat_dir, "PSM\\cache", paste0(dat_id, "_header.txt"))
+  dat_file <- file.path(dat_dir, "PSM/cache", paste0(dat_id, "_header.txt"))
   stopifnot(length(dat_id)== 1, file.exists(dat_file))
   
   df_header <- readLines(dat_file)
@@ -689,7 +689,7 @@ add_mascot_pepseqmod <- function(df, use_lowercase_aa) {
     try(
       df %>% 
         dplyr::filter(grepl(.x, pep_var_mod, fixed = TRUE)) %>% 
-        write.table(file.path(dat_dir, "PSM\\individual_mods", paste0(.y, ".txt")), 
+        write.table(file.path(dat_dir, "PSM/individual_mods", paste0(.y, ".txt")), 
                     sep = "\t", col.names = TRUE, row.names = FALSE)
     )
   })
@@ -745,15 +745,15 @@ splitPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", fasta 
 
 	TMT_plex <- TMT_plex(label_scheme_full)
 
-  filelist = list.files(path = file.path(dat_dir, "PSM\\cache"),
-                        pattern = "^F[0-9]+\\_hdr_rm.csv$")
+  filelist = list.files(path = file.path(dat_dir, "PSM/cache"),
+                        pattern = "^F[0-9]+_hdr_rm.csv$")
 
 	if (length(filelist) == 0) 
-	  stop(paste("No intermediate PSM file(s) under: ", file.path(dat_dir, "PSM//cache")), 
+	  stop(paste("No intermediate PSM file(s) under: ", file.path(dat_dir, "PSM/cache")), 
 	       call. = FALSE)
 
   df <- purrr::map(filelist, ~ {
-    data <- read.delim(file.path(dat_dir, "PSM\\cache", .x), sep = ',', check.names = FALSE, 
+    data <- read.delim(file.path(dat_dir, "PSM/cache", .x), sep = ',', check.names = FALSE, 
                        header = TRUE, stringsAsFactors = FALSE, quote = "\"",fill = TRUE , skip = 0) %>% 
       pad_mascot_channels(TMT_plex)
     
@@ -999,14 +999,14 @@ splitPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", fasta 
 
 		df_split[[i]] <- df_split[[i]] %>% dplyr::rename(raw_file = RAW_File)
 		
-		write.csv(df_split[[i]], file.path(dat_dir, "PSM\\cache", out_fn), row.names = FALSE)
+		write.csv(df_split[[i]], file.path(dat_dir, "PSM/cache", out_fn), row.names = FALSE)
 		
 		if (plot_rptr_int & TMT_plex > 0) {
 		  df_int <- df_split[[i]] %>% 
 		    .[, grepl("^I[0-9]{3}", names(.))]
 		  
 		  rptr_violin(df = df_int, 
-		              filepath = file.path(dat_dir, "PSM\\rprt_int\\raw", gsub("\\.csv", "\\.png", out_fn)), 
+		              filepath = file.path(dat_dir, "PSM/rprt_int/raw", gsub("\\.csv", "\\.png", out_fn)), 
 		              width = 8, height = 8)
 		}
 	}
@@ -1289,18 +1289,18 @@ cleanupPSM <- function(rm_outliers = FALSE) {
 	load(file = file.path(dat_dir, "label_scheme_full.rda"))
 	TMT_plex <- TMT_plex(label_scheme_full)
 
-	filelist = list.files(path = file.path(dat_dir, "PSM\\cache"),
+	filelist = list.files(path = file.path(dat_dir, "PSM/cache"),
 	                      pattern = "^TMT.*LCMS.*\\.csv$")
 
 	for (i in seq_along(filelist)) {
-		df <- read.csv(file.path(dat_dir, "PSM\\cache", filelist[i]), check.names = FALSE,
+		df <- read.csv(file.path(dat_dir, "PSM/cache", filelist[i]), check.names = FALSE,
 		               header = TRUE, comment.char = "#")
 
 		if (TMT_plex == 0) {
 			# lable-free data
 		  # re-save ".csv" as ".txt"
 			fn <- paste0(gsub(".csv", "", filelist[i]), "_Clean.txt")
-			write.table(df, file.path(dat_dir, "PSM\\cache", fn), sep = "\t", col.names = TRUE,
+			write.table(df, file.path(dat_dir, "PSM/cache", fn), sep = "\t", col.names = TRUE,
 			            row.names = FALSE)
 			cat(filelist[i], "processed\n")
 
@@ -1385,7 +1385,7 @@ cleanupPSM <- function(rm_outliers = FALSE) {
 		}
 
 		fn <- paste0(gsub(".csv", "", filelist[i]), "_Clean.txt")
-		write.table(df, file.path(dat_dir, "PSM\\cache", fn), sep = "\t", col.names = TRUE,
+		write.table(df, file.path(dat_dir, "PSM/cache", fn), sep = "\t", col.names = TRUE,
 		            row.names = FALSE)
 		cat(filelist[i], "processed\n")
 	}
@@ -1531,9 +1531,9 @@ annotPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_psm
                      fasta = NULL, expt_smry = "expt_smry.xlsx", 
                      plot_rptr_int = TRUE, plot_log2FC_cv = TRUE, ...) {
   
-  hd_fn <- list.files(path = file.path(dat_dir, "PSM\\cache"),
+  hd_fn <- list.files(path = file.path(dat_dir, "PSM/cache"),
                       pattern = "^F\\d+_header.txt$")
-  assign("df_header", readLines(file.path(dat_dir, "PSM\\cache", hd_fn[1])))
+  assign("df_header", readLines(file.path(dat_dir, "PSM/cache", hd_fn[1])))
   
   load(file = file.path(dat_dir, "label_scheme_full.rda"))
   load(file = file.path(dat_dir, "label_scheme.rda"))
@@ -1541,7 +1541,7 @@ annotPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_psm
   TMT_plex <- TMT_plex(label_scheme_full)
   
   filelist <- list.files(
-    path = file.path(dat_dir, "PSM\\cache"),
+    path = file.path(dat_dir, "PSM/cache"),
     pattern = "^TMT.*LCMS.*_Clean.txt$"
   ) %>%
     reorder_files(n_TMT_sets)
@@ -1558,7 +1558,7 @@ annotPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_psm
     
     # LCMS injections under the same TMT experiment
     for (injn_idx in seq_along(sublist)) {
-      df <- read.csv(file.path(dat_dir, "PSM\\cache", sublist[injn_idx]),
+      df <- read.csv(file.path(dat_dir, "PSM/cache", sublist[injn_idx]),
                      check.names = FALSE, header = TRUE, sep = "\t",
                      comment.char = "#")
 
@@ -1625,14 +1625,14 @@ annotPSM <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_psm
       if (plot_rptr_int && TMT_plex > 0) {
         df_int <- df %>% .[, grepl("^N_I[0-9]{3}", names(.))]
         rptr_violin(df = df_int, 
-                    filepath = file.path(dat_dir, "PSM\\rprt_int\\mc",
+                    filepath = file.path(dat_dir, "PSM/rprt_int/mc",
                                          paste0(gsub("_PSM_N", "", out_fn[injn_idx, 1]), "_rprt.png")), 
                     width = 8, height = 8)
       }
 
       if (plot_log2FC_cv && TMT_plex > 0) {
         sd_violin(df = df, id = !!group_psm_by, 
-                  filepath = file.path(dat_dir, "PSM\\log2FC_cv\\raw", 
+                  filepath = file.path(dat_dir, "PSM/log2FC_cv/raw", 
                                        paste0(gsub("_PSM_N", "", out_fn[injn_idx, 1]), "_sd.png")), 
                   width = 8, height = 8, type = "log2_R", adjSD = FALSE, is_psm = TRUE)
       }
@@ -1883,12 +1883,12 @@ normPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by = c
     stopifnot(group_pep_by %in% c("prot_acc", "gene"), length(group_pep_by) == 1)
   }
 
-  dir.create(file.path(dat_dir, "PSM\\cache"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\rprt_int\\raw"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\rprt_int\\mc"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\log2FC_cv\\raw"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\log2FC_cv\\purged"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\individual_mods"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/rprt_int/raw"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/rprt_int/mc"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/log2FC_cv/raw"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/log2FC_cv/purged"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/individual_mods"), recursive = TRUE, showWarnings = FALSE)
   
   if (!purrr::is_empty(list.files(path = file.path(dat_dir), pattern = "^F[0-9]+\\.csv$"))) {
     type <- "mascot"
@@ -2210,7 +2210,7 @@ PSM2Pep <- function (method_psm_pep = c("median", "mean", "weighted.mean", "top.
   load(file = file.path(dat_dir, "label_scheme_full.rda"))
   load(file = file.path(dat_dir, "label_scheme.rda"))
   
-  dir.create(file.path(dat_dir, "Peptide\\cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/cache"), recursive = TRUE, showWarnings = FALSE)
   
   filelist <- list.files(path = file.path(dat_dir, "PSM"), pattern = "*_PSM_N\\.txt$") %>%
     reorder_files(n_TMT_sets(label_scheme_full))
@@ -2725,13 +2725,13 @@ splitPSM_mq <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", fas
     
     df_split[[i]] <- df_split[[i]] %>% dplyr::rename(raw_file = RAW_File)
     
-    write.csv(df_split[[i]], file.path(dat_dir, "PSM\\cache", out_fn), row.names = FALSE)
+    write.csv(df_split[[i]], file.path(dat_dir, "PSM/cache", out_fn), row.names = FALSE)
     
     if (plot_rptr_int & TMT_plex > 0) {
       df_int <- df_split[[i]] %>% 
         .[, grepl("^I[0-9]{3}", names(.))]
       
-      rptr_violin(df = df_int, filepath = file.path(dat_dir, "PSM\\rprt_int\\raw", gsub("\\.csv", "\\.png", out_fn)), 
+      rptr_violin(df = df_int, filepath = file.path(dat_dir, "PSM/rprt_int/raw", gsub("\\.csv", "\\.png", out_fn)), 
                   width = 8, height = 8)
     }
   }
@@ -2761,7 +2761,7 @@ annotPSM_mq <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_
   TMT_plex <- TMT_plex(label_scheme_full)
   
   filelist <- list.files(
-    path = file.path(dat_dir, "PSM\\cache"),
+    path = file.path(dat_dir, "PSM/cache"),
     pattern = "^TMT.*LCMS.*_Clean.txt$"
   ) %>%
     reorder_files(., n_TMT_sets)
@@ -2777,7 +2777,7 @@ annotPSM_mq <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_
     
     # LCMS injections under the same TMT experiment
     for (injn_idx in seq_along(sublist)) {
-      df <- read.csv(file.path(dat_dir, "PSM\\cache", sublist[injn_idx]),
+      df <- read.csv(file.path(dat_dir, "PSM/cache", sublist[injn_idx]),
                      check.names = FALSE, header = TRUE, sep = "\t",
                      comment.char = "#") %>%
         dplyr::rename(pep_seq_mod = `Modified sequence`) %>%
@@ -2854,14 +2854,14 @@ annotPSM_mq <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_
       if (plot_rptr_int && TMT_plex > 0) {
         df_int <- df %>% .[, grepl("^N_I[0-9]{3}", names(.))]
         rptr_violin(df = df_int, 
-                    filepath = file.path(dat_dir, "PSM\\rprt_int\\mc", 
+                    filepath = file.path(dat_dir, "PSM/rprt_int/mc", 
                                          paste0(gsub("_PSM_N", "", out_fn[injn_idx, 1]), "_rprt.png")), 
                     width = 8, height = 8)
       }
       
       if (plot_log2FC_cv && TMT_plex > 0) {
         sd_violin(df = df, id = !!group_psm_by, 
-                  filepath = file.path(dat_dir, "PSM\\log2FC_cv\\raw", 
+                  filepath = file.path(dat_dir, "PSM/log2FC_cv/raw", 
                                        paste0(gsub("_PSM_N", "", out_fn[injn_idx, 1]), "_sd.png")), 
                   width = 8, height = 8, type = "log2_R", adjSD = FALSE, is_psm = TRUE)
       }
@@ -3184,13 +3184,13 @@ splitPSM_sm <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", fas
     
     df_split[[i]] <- df_split[[i]] %>% dplyr::rename(raw_file = RAW_File)
     
-    write.csv(df_split[[i]], file.path(dat_dir, "PSM\\cache", out_fn), row.names = FALSE)
+    write.csv(df_split[[i]], file.path(dat_dir, "PSM/cache", out_fn), row.names = FALSE)
     
     if (plot_rptr_int & TMT_plex > 0) {
       df_int <- df_split[[i]] %>% 
         .[, grepl("^I[0-9]{3}", names(.))]
       
-      rptr_violin(df = df_int, filepath = file.path(dat_dir, "PSM\\rprt_int\\raw", gsub("\\.csv", "\\.png", out_fn)), 
+      rptr_violin(df = df_int, filepath = file.path(dat_dir, "PSM/rprt_int/raw", gsub("\\.csv", "\\.png", out_fn)), 
                   width = 8, height = 8)
     }
   }
@@ -3221,7 +3221,7 @@ annotPSM_sm <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_
   TMT_plex <- TMT_plex(label_scheme_full)
   
   filelist <- list.files(
-    path = file.path(dat_dir, "PSM\\cache"),
+    path = file.path(dat_dir, "PSM/cache"),
     pattern = "^TMT.*LCMS.*_Clean.txt$"
   ) %>%
     reorder_files(., n_TMT_sets)
@@ -3237,7 +3237,7 @@ annotPSM_sm <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_
     channelInfo <- channelInfo(label_scheme, set_idx)
     
     for (injn_idx in seq_along(sublist)) {
-      df <- read.csv(file.path(dat_dir, "PSM\\cache", sublist[injn_idx]),
+      df <- read.csv(file.path(dat_dir, "PSM/cache", sublist[injn_idx]),
                      check.names = FALSE, header = TRUE, sep = "\t",
                      comment.char = "#") %>%
         dplyr::mutate(pep_seq_mod = pep_seq) %>% 
@@ -3404,14 +3404,14 @@ annotPSM_sm <- function(group_psm_by = "pep_seq", group_pep_by = "prot_acc", mc_
           .[, grepl("^N_I[0-9]{3}", names(.))]
         
         rptr_violin(df = df_int, 
-                    filepath = file.path(dat_dir, "PSM\\rprt_int\\mc", 
+                    filepath = file.path(dat_dir, "PSM/rprt_int/mc", 
                                          paste0(gsub("_PSM_N", "", out_fn[injn_idx, 1]), "_rprt.png")), 
                     width = 8, height = 8)
       }
       
       if (plot_log2FC_cv & TMT_plex > 0) {
         sd_violin(df = df, id = !!group_psm_by, 
-                  filepath = file.path(dat_dir, "PSM\\log2FC_cv\\raw", 
+                  filepath = file.path(dat_dir, "PSM/log2FC_cv/raw", 
                                        paste0(gsub("_PSM_N", "", out_fn[injn_idx, 1]), "_sd.png")), 
                   width = 8, height = 8, type = "log2_R", adjSD = FALSE, is_psm = TRUE)
       }

--- a/R/purge.R
+++ b/R/purge.R
@@ -290,7 +290,7 @@ purgePSM <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
   } else {
     assign("dat_dir", dat_dir, envir = .GlobalEnv)
   }
-  dir.create(file.path(dat_dir, "PSM\\log2FC_cv\\purged"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/log2FC_cv/purged"), recursive = TRUE, showWarnings = FALSE)
   
   group_psm_by <- match_call_arg(normPSM, group_psm_by)
   group_pep_by <- match_call_arg(normPSM, group_pep_by)
@@ -310,10 +310,10 @@ purgePSM <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
   filelist <- list.files(path = file.path(dat_dir, "PSM"), pattern = "*_PSM_N\\.txt$") %>%
     reorder_files(n_TMT_sets(label_scheme_full))
   
-  dir.create(file.path(dat_dir, "PSM\\Copy"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/Copy"), recursive = TRUE, showWarnings = FALSE)
 
   for (fn in filelist) {
-    file.copy(file.path(dat_dir, "PSM", fn), file.path(dat_dir, "PSM\\Copy", fn))
+    file.copy(file.path(dat_dir, "PSM", fn), file.path(dat_dir, "PSM/Copy", fn))
     
     df <- read.csv(file.path(dat_dir, "PSM", fn), check.names = FALSE, 
                    header = TRUE, sep = "\t", comment.char = "#") %>% 
@@ -361,7 +361,7 @@ purgePSM <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
     if (is.null(height)) height <- 8
     dots <- dots %>% .[! names(.) %in% c("width", "height")]
 
-    filepath <- file.path(dat_dir, "PSM\\log2FC_cv\\purged", gsub("_PSM_N.txt", "_sd.png", fn))
+    filepath <- file.path(dat_dir, "PSM/log2FC_cv/purged", gsub("_PSM_N.txt", "_sd.png", fn))
     quiet_out <- purrr::quietly(sd_violin)(df = df, id = !!group_psm_by, filepath = filepath, 
                                            width = width, height = height, type = "log2_R", adjSD = FALSE, 
                                            is_psm = TRUE, col_select = NULL, col_order = NULL, 
@@ -490,7 +490,7 @@ purgePep <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
   } else {
     assign("dat_dir", dat_dir, envir = .GlobalEnv)
   }
-  dir.create(file.path(dat_dir, "Peptide\\log2FC_cv\\purged"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Peptide/log2FC_cv/purged"), recursive = TRUE, showWarnings = FALSE)
   
   group_psm_by <- match_call_arg(normPSM, group_psm_by)
   group_pep_by <- match_call_arg(normPSM, group_pep_by)
@@ -507,8 +507,8 @@ purgePep <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
   load(file = file.path(dat_dir, "label_scheme_full.rda"))
   load(file = file.path(dat_dir, "label_scheme.rda"))
 
-  dir.create(file.path(dat_dir, "Peptide\\Copy"), recursive = TRUE, showWarnings = FALSE)
-  file.copy(file.path(dat_dir, "Peptide\\Peptide.txt"), file.path(dat_dir, "Peptide\\Copy\\Peptide.txt"))
+  dir.create(file.path(dat_dir, "Peptide/Copy"), recursive = TRUE, showWarnings = FALSE)
+  file.copy(file.path(dat_dir, "Peptide/Peptide.txt"), file.path(dat_dir, "Peptide/Copy/Peptide.txt"))
   
   fn <- file.path(dat_dir, "Peptide", "Peptide.txt")
   df <- read.csv(fn, check.names = FALSE, header = TRUE, sep = "\t", comment.char = "#") %>% 
@@ -557,7 +557,7 @@ purgePep <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
   if (is.null(height)) height <- 8
   dots <- dots %>% .[! names(.) %in% c("width", "height")]
   
-  filepath <- file.path(dat_dir, "Peptide\\log2FC_cv\\purged", filename)
+  filepath <- file.path(dat_dir, "Peptide/log2FC_cv/purged", filename)
   quiet_out <- purrr::quietly(sd_violin)(df = df, id = !!group_pep_by, filepath = filepath, 
                                          width = width, height = height, type = "log2_R", 
                                          adjSD = FALSE, is_psm = FALSE, 

--- a/R/purge.R
+++ b/R/purge.R
@@ -308,7 +308,7 @@ purgePSM <- function (dat_dir = NULL, pt_cv = NULL, max_cv = NULL, adjSD = FALSE
   load(file = file.path(dat_dir, "label_scheme.rda"))
   
   filelist <- list.files(path = file.path(dat_dir, "PSM"), pattern = "*_PSM_N\\.txt$") %>%
-    reorder_files(n_TMT_sets(label_scheme_full))
+    reorder_files()
   
   dir.create(file.path(dat_dir, "PSM/Copy"), recursive = TRUE, showWarnings = FALSE)
 

--- a/R/sigtests.R
+++ b/R/sigtests.R
@@ -385,7 +385,7 @@ sigTest <- function(df, id, label_scheme_sub,
 	
 	if (id %in% c("pep_seq", "pep_seq_mod")) {
 	  pepSig_formulas <- dots
-	  save(pepSig_formulas, file = file.path(dat_dir, "Calls\\pepSig_formulas.rda"))
+	  save(pepSig_formulas, file = file.path(dat_dir, "Calls/pepSig_formulas.rda"))
 	  rm(pepSig_formulas)
 	} else if (id %in% c("prot_acc", "gene")) {
 	  if (rlang::is_empty(dots)) {
@@ -417,9 +417,9 @@ sigTest <- function(df, id, label_scheme_sub,
 	})
 
 	if (id %in% c("pep_seq", "pep_seq_mod")) {
-	  out_path <- file.path(dat_dir, "Peptide\\Model\\log\\pepSig_log.txt")
+	  out_path <- file.path(dat_dir, "Peptide/Model/log/pepSig_log.txt")
 	} else if (id %in% c("prot_acc", "gene")) {
-	  out_path <- file.path(dat_dir, "Protein\\Model\\log\\prnSig_log.txt")
+	  out_path <- file.path(dat_dir, "Protein/Model/log/prnSig_log.txt")
 	}
 	
 	purrr::map(quietly_log, ~ {
@@ -563,8 +563,8 @@ pepSig <- function (scale_log2r = TRUE, impute_na = TRUE, complete_cases = FALSE
 #'  \code{Protein[_impNA].txt}. See also \code{\link{normPSM}} for the format of
 #'  \code{filter_} statements.
 #'@return The primary output is
-#'  \code{~\\dat_dir\\Peptide\\Model\\Peptide_pVals.txt} for peptide data or
-#'  \code{~\\dat_dir\\Protein\\Model\\Protein_pVals.txt} for protein data. At
+#'  \code{~/dat_dir/Peptide/Model/Peptide_pVals.txt} for peptide data or
+#'  \code{~/dat_dir/Protein/Model/Protein_pVals.txt} for protein data. At
 #'  \code{impute_na = TRUE}, the corresponding outputs are
 #'  \code{Peptide_impNA_pvals.txt} or \code{Protein_impNA_pvals.txt}.
 #'
@@ -639,7 +639,7 @@ prnSig <- function (scale_log2r = TRUE, impute_na = TRUE, complete_cases = FALSE
                     var_cutoff = 1E-3, pval_cutoff = 1.00, logFC_cutoff = log2(1), 
                     df = NULL, filepath = NULL, filename = NULL, ...) {
   on.exit({
-    load(file.path(dat_dir, "Calls\\prnSig_formulas.rda"))
+    load(file.path(dat_dir, "Calls/prnSig_formulas.rda"))
     dots <- my_union(rlang::enexprs(...), prnSig_formulas)
     mget(names(formals()), current_env()) %>% c(dots) %>% save_call("prnSig")
   }, add = TRUE)

--- a/R/simulData.R
+++ b/R/simulData.R
@@ -32,11 +32,11 @@ mascot_refseq2uniprot <- function(dat_dir) {
   
   suppressMessages(rmPSMHeaders())
   
-  filelist <- list.files(path = file.path(dat_dir, "PSM\\cache"), pattern = "^F[0-9]{6}\\_hdr_rm.csv$")
-  filelist_hdr <- list.files(path = file.path(dat_dir, "PSM\\cache"), pattern = "^F[0-9]{6}\\_header.txt$")
+  filelist <- list.files(path = file.path(dat_dir, "PSM/cache"), pattern = "^F[0-9]{6}_hdr_rm.csv$")
+  filelist_hdr <- list.files(path = file.path(dat_dir, "PSM/cache"), pattern = "^F[0-9]{6}_header.txt$")
   
   purrr::walk2(filelist, filelist_hdr, ~ {
-    df <- read.delim(file.path(dat_dir, "PSM\\cache", .x), sep = ',', check.names = FALSE, 
+    df <- read.delim(file.path(dat_dir, "PSM/cache", .x), sep = ',', check.names = FALSE, 
                      header = TRUE, stringsAsFactors = FALSE, quote = "\"",fill = TRUE , skip = 0)
     df$psm_index <- seq_along(1:nrow(df))
     
@@ -98,15 +98,15 @@ mascot_refseq2uniprot <- function(dat_dir) {
     df[["prot_acc"]] <- unlist(uniprot_acc)
     df[["psm_index"]] <- NULL
     
-    dir.create(file.path(dat_dir, "PSM\\cache\\temp"))
-    write.table(df, file = file.path(dat_dir, "PSM\\cache\\temp", .x), sep = ",")
-    df <- readLines(file.path(dat_dir, "PSM\\cache\\temp", .x))
-    hdr <- readLines(file.path(dat_dir, "PSM\\cache", .y))
+    dir.create(file.path(dat_dir, "PSM/cache/temp"))
+    write.table(df, file = file.path(dat_dir, "PSM/cache/temp", .x), sep = ",")
+    df <- readLines(file.path(dat_dir, "PSM/cache/temp", .x))
+    hdr <- readLines(file.path(dat_dir, "PSM/cache", .y))
     
     write(append(hdr, df), file = file.path(dat_dir, gsub("_hdr_rm", "", .x)))
   })
   
-  unlink(file.path(dat_dir, "PSM\\cache\\temp"), recursive = TRUE)
+  unlink(file.path(dat_dir, "PSM/cache/temp"), recursive = TRUE)
 }
 
 

--- a/R/specialty.R
+++ b/R/specialty.R
@@ -9,7 +9,7 @@
 #' @examples 
 #' \donttest{
 #' res <- labEffPSM(
-#'   fasta = c("~\\proteoQ\\dbs\\fasta\\uniprot\\uniprot_mm_2014_07.fasta"),
+#'   fasta = c("~/proteoQ/dbs/fasta/uniprot/uniprot_mm_2014_07.fasta"),
 #' )
 #' }
 #' @export
@@ -48,12 +48,12 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
     stopifnot(group_pep_by %in% c("prot_acc", "gene"))
   }
   
-  dir.create(file.path(dat_dir, "PSM\\cache"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\rprt_int\\raw"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\rprt_int\\mc"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\log2FC_cv\\raw"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\log2FC_cv\\purged"), recursive = TRUE, showWarnings = FALSE)
-  dir.create(file.path(dat_dir, "PSM\\individual_mods"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/rprt_int/raw"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/rprt_int/mc"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/log2FC_cv/raw"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/log2FC_cv/purged"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/individual_mods"), recursive = TRUE, showWarnings = FALSE)
   
   if (!purrr::is_empty(list.files(path = file.path(dat_dir), pattern = "^F[0-9]+\\.csv$"))) {
     type <- "mascot"
@@ -79,8 +79,8 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
   
   TMT_plex <- TMT_plex(label_scheme_full)
   
-  filelist = list.files(path = file.path(dat_dir, "PSM\\cache"),
-                        pattern = "^F[0-9]{6}\\_hdr_rm.csv$")
+  filelist = list.files(path = file.path(dat_dir, "PSM/cache"),
+                        pattern = "^F[0-9]{6}_hdr_rm.csv$")
   
   if (length(filelist) == 0) stop(paste("No PSM files under", file.path(dat_dir, "PSM")))
   
@@ -92,7 +92,7 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
                                   call. = FALSE)
   
   df <- purrr::map(filelist, ~ {
-    df <- read.delim(file.path(dat_dir, "PSM\\cache", .x), sep = ',', check.names = FALSE, 
+    df <- read.delim(file.path(dat_dir, "PSM/cache", .x), sep = ',', check.names = FALSE, 
                      header = TRUE, stringsAsFactors = FALSE, quote = "\"",fill = TRUE , skip = 0)
     df$dat_file <- gsub("_hdr_rm\\.csv", "", .x)
     
@@ -132,7 +132,7 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
     }
     
     dat_id <- df$dat_file %>% unique()
-    dat_file <- file.path(dat_dir, "PSM\\cache", paste0(dat_id, "_header.txt"))
+    dat_file <- file.path(dat_dir, "PSM/cache", paste0(dat_id, "_header.txt"))
     stopifnot(length(dat_id)== 1, file.exists(dat_file))
     
     df_header <- readLines(dat_file)
@@ -283,7 +283,7 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
       dplyr::summarize(N = n()) %>% 
       dplyr::right_join(dat_files, by = "dat_file") %>% 
       dplyr::arrange(-N, dat_file) %T>% 
-      write.csv(file.path(dat_dir, "PSM\\cache", paste0(.y, ".csv")), row.names = FALSE)
+      write.csv(file.path(dat_dir, "PSM/cache", paste0(.y, ".csv")), row.names = FALSE)
     
     both <- res %>% 
       dplyr::filter(tmt_type == "both") %>% 
@@ -321,7 +321,7 @@ labEffPSM <- function(group_psm_by = c("pep_seq", "pep_seq_mod"), group_pep_by =
 #'   df = Protein_delta.txt, 
 #'   id = gene, 
 #'   df_meta = hm_meta.xlsx, 
-#'   filepath = file.path(dat_dir, "Protein\\Heatmap"), 
+#'   filepath = file.path(dat_dir, "Protein/Heatmap"), 
 #'   filename = "kin_delta.png",
 #'   complete_cases = FALSE, 
 #'   annot_cols = NULL, 

--- a/R/string.R
+++ b/R/string.R
@@ -57,7 +57,7 @@ annot_stringdb <- function(df, db_nms, id, score_cutoff, filepath = NULL, filena
   outnm_ppi <- paste0(fn_prefix, "_ppi.tsv")
   outnm_expr <- paste0(fn_prefix, "_expr.tsv")
 
-  write.table(ppi, file.path(dat_dir, "Protein\\String", outnm_ppi), 
+  write.table(ppi, file.path(dat_dir, "Protein/String", outnm_ppi), 
               quote = FALSE, sep = "\t", row.names = FALSE)
   
   # --- expression data ---
@@ -72,7 +72,7 @@ annot_stringdb <- function(df, db_nms, id, score_cutoff, filepath = NULL, filena
 
   suppressWarnings(df[is.na(df)] <- "") # Cytoscape compatibility
 
-  write.table(df, file.path(dat_dir, "Protein\\String", outnm_expr), 
+  write.table(df, file.path(dat_dir, "Protein/String", outnm_expr), 
               quote = FALSE, sep = "\t", row.names = FALSE)
   
 }
@@ -118,7 +118,7 @@ stringTest <- function(df = NULL, id = gene,
   
   if (score_cutoff <= 1) score_cutoff <- score_cutoff * 1000
   
-  dir.create(file.path(dat_dir, "Protein\\String\\cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/String/cache"), recursive = TRUE, showWarnings = FALSE)
 
   annot_stringdb(df, db_nms, id, score_cutoff, filepath, filename)
 }
@@ -203,7 +203,7 @@ anal_prnString <- function (scale_log2r = TRUE, complete_cases = FALSE, impute_n
 #'name lookups.
 #'
 #'@param db_path Character string; the local path for database(s). The default
-#'  is \code{"~\\proteoQ\\dbs\\string"}.
+#'  is \code{"~/proteoQ/dbs/string"}.
 #'@param species Character string; the name of a species for the
 #'  \emph{conveninent} preparation of STRING databases. The species available
 #'  for the convenience feature is in one of \code{c("human", "mouse", "rat")}
@@ -245,7 +245,7 @@ anal_prnString <- function (scale_log2r = TRUE, complete_cases = FALSE, impute_n
 #'@export
 prepString <- function(species = "human", # abbr_species = NULL, 
                        links_url = NULL, aliases_url = NULL, info_url = NULL, 
-                       db_path = "~\\proteoQ\\dbs\\string", filename = NULL, overwrite = FALSE) {
+                       db_path = "~/proteoQ/dbs/string", filename = NULL, overwrite = FALSE) {
   
   old_opts <- options()
   options(warn = 1)
@@ -408,8 +408,8 @@ prepString <- function(species = "human", # abbr_species = NULL,
 #' prepString(mouse)
 #' 
 #' load_stringdbs(
-#'   db_nms = c("~\\proteoQ\\dbs\\string\\string_hs.rds",
-#'              "~\\proteoQ\\dbs\\string\\string_mm.rds")
+#'   db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+#'              "~/proteoQ/dbs/string/string_mm.rds")
 #' )
 #' }
 #'

--- a/R/trends.R
+++ b/R/trends.R
@@ -29,6 +29,8 @@ analTrend <- function (df, id, col_group, col_order, label_scheme_sub, n_clust,
 	  prepDM(id = !!id, scale_log2r = scale_log2r, 
 	         sub_grp = label_scheme_sub$Sample_ID, anal_type = anal_type) %>% 
 	  .$log2R
+	
+	label_scheme_sub <- label_scheme_sub %>% dplyr::filter(Sample_ID %in% colnames(df_num))
 
 	col_group <- rlang::enexpr(col_group)
 	col_order <- rlang::enexpr(col_order)

--- a/R/trends.R
+++ b/R/trends.R
@@ -236,9 +236,9 @@ plotTrend <- function(id, col_group, col_order, label_scheme_sub, n_clust,
     )
 
     if (!is.null(dim(df))) {
-      message(paste("File loaded:", gsub("\\\\", "/", src_path)))
+      message(paste("File loaded:", src_path))
     } else {
-      stop(paste("Non-existed file or directory:", gsub("\\\\", "/", src_path)))
+      stop(paste("Non-existed file or directory:", src_path))
     }
     
     Levels <- label_scheme_sub %>% 
@@ -389,11 +389,14 @@ plotTrend <- function(id, col_group, col_order, label_scheme_sub, n_clust,
 #'  \code{\link{pepHM}} and \code{\link{prnHM}} for heat map visualization \cr 
 #'  \code{\link{pepCorr_logFC}}, \code{\link{prnCorr_logFC}}, \code{\link{pepCorr_logInt}} and 
 #'  \code{\link{prnCorr_logInt}}  for correlation plots \cr 
-#'  \code{\link{anal_prnTrend}} and \code{\link{plot_prnTrend}} for trend analysis and visualization \cr 
-#'  \code{\link{cluego}} for the visualization of \code{\link{anal_prnTrend}} via \code{Cytoscape} \cr 
-#'  \code{\link{anal_pepNMF}}, \code{\link{anal_prnNMF}}, \code{\link{plot_pepNMFCon}}, 
-#'  \code{\link{plot_prnNMFCon}}, \code{\link{plot_pepNMFCoef}}, \code{\link{plot_prnNMFCoef}} and 
-#'  \code{\link{plot_metaNMF}} for NMF analysis and visualization \cr 
+#'  \code{\link{anal_prnTrend}} and \code{\link{plot_prnTrend}} for trend
+#'  analysis and visualization \cr \code{\link{cluego}} for the visualization of
+#'  \code{\link{anal_prnTrend}} and \code{\link{plot_prnTrend}} via
+#'  \code{Cytoscape/ClueGO} \cr \code{\link{anal_pepNMF}},
+#'  \code{\link{anal_prnNMF}}, \code{\link{plot_pepNMFCon}},
+#'  \code{\link{plot_prnNMFCon}}, \code{\link{plot_pepNMFCoef}},
+#'  \code{\link{plot_prnNMFCoef}} and \code{\link{plot_metaNMF}} for NMF
+#'  analysis and visualization \cr
 #'  
 #'  \emph{Custom databases} \cr 
 #'  \code{\link{Uni2Entrez}} for lookups between UniProt accessions and Entrez IDs \cr 
@@ -439,7 +442,7 @@ anal_prnTrend <- function (col_select = NULL, col_group = NULL, col_order = NULL
   if (any(names(rlang::enexprs(...)) %in% c("x"))) stop(err_msg1, call. = FALSE)
   if (any(names(rlang::enexprs(...)) %in% c("centers"))) stop(err_msg2, call. = FALSE)
 
-  dir.create(file.path(dat_dir, "Protein\\Trend\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/Trend/log"), recursive = TRUE, showWarnings = FALSE)
 
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)
@@ -468,7 +471,7 @@ anal_prnTrend <- function (col_select = NULL, col_group = NULL, col_order = NULL
 #'\code{\link{anal_prnTrend}}.
 #'
 #'The function reads \code{Protein_Trend_[...].txt} files under the
-#'\code{...\\Protein\\Trend} directory.
+#'\code{.../Protein/Trend} directory.
 #'
 #'@section \code{Protein_Trend_[...].txt}:
 #'
@@ -583,7 +586,7 @@ plot_prnTrend <- function (col_select = NULL, col_order = NULL, n_clust = NULL,
                            df2 = NULL, filename = NULL, theme = NULL, ...) {
   check_dots(c("id", "anal_type", "df", "col_group", "filepath"), ...)
   
-  dir.create(file.path(dat_dir, "Protein\\Trend\\log"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "Protein/Trend/log"), recursive = TRUE, showWarnings = FALSE)
 
   id <- match_call_arg(normPSM, group_pep_by)
   stopifnot(rlang::as_string(id) %in% c("prot_acc", "gene"), length(id) == 1)

--- a/R/utils.R
+++ b/R/utils.R
@@ -589,14 +589,14 @@ imputeNA <- function (id, overwrite = FALSE, ...) {
 		                        comment.char = "#"), error = function(e) NA)
 
 		if (!is.null(dim(df))) {
-			message(paste("File loaded:", gsub("\\\\", "/", src_path)))
+		  message(paste("File loaded:", src_path))
 		} else {
-			stop(paste("File or directory not found:", gsub("\\\\", "/", src_path)))
+		  stop(paste("File or directory not found:", src_path))
 		}
 
 		df[, grep("N_log2_R", names(df))]  <- df[, grep("N_log2_R", names(df))]  %>% handleNA(...)
 
-		fn_params <- file.path(dat_dir, "Protein\\Histogram", "MGKernel_params_N.txt")
+		fn_params <- file.path(dat_dir, "Protein/Histogram", "MGKernel_params_N.txt")
 		if (file.exists(fn_params)) {
 			cf_SD <- 
 				read.csv(fn_params, check.names = FALSE, header = TRUE, sep = "\t", comment.char = "#") %>%
@@ -1186,7 +1186,7 @@ get_gl_dat_dir <- function () {
   dat_dir <- tryCatch(get("dat_dir", envir = .GlobalEnv), error = function(e) 1)
   if (dat_dir == 1) {
     stop("Unknown working directory; 
-         run `load_expts(\"my\\\\fabulous\\\\working\\\\directory\")` first.", 
+         run `load_expts(\"my/fabulous/working/directory\")` first.", 
          call. = FALSE)
   }
   
@@ -1200,7 +1200,7 @@ get_gl_dat_dir <- function () {
 #' @import plyr dplyr purrr rlang
 #' @importFrom magrittr %>%
 match_fmls <- function(formulas) {
-  fml_file <-  file.path(dat_dir, "Calls\\pepSig_formulas.rda")
+  fml_file <-  file.path(dat_dir, "Calls/pepSig_formulas.rda")
   
   if (file.exists(fml_file)) {
     load(file = fml_file)
@@ -1260,14 +1260,14 @@ match_gspa_filename <- function (anal_type = "GSPA", subdir = NULL, scale_log2r 
   stopifnot(!is.null(subdir))
 
   if (anal_type == "GSPA") {
-    file <- file.path(dat_dir, "Calls\\anal_prnGSPA.rda")
+    file <- file.path(dat_dir, "Calls/anal_prnGSPA.rda")
     if (!file.exists(file)) stop("Run `prnGSPA` first.", call. = FALSE)
     load(file = file)
   }
   
   filename <- call_pars$filename
   if (rlang::is_empty(filename)) {
-    filename <- list.files(path = file.path(dat_dir, "Protein\\GSPA", subdir), 
+    filename <- list.files(path = file.path(dat_dir, "Protein/GSPA", subdir), 
                            pattern = "^Protein_GSPA_.*\\.txt$", 
                            full.names = FALSE)
     
@@ -1292,7 +1292,7 @@ match_gspa_filename <- function (anal_type = "GSPA", subdir = NULL, scale_log2r 
 #' 
 #' @inheritParams prnGSPA
 match_gset_nms <- function (gset_nms = NULL) {
-  file <- file.path(dat_dir, "Calls\\anal_prnGSPA.rda")
+  file <- file.path(dat_dir, "Calls/anal_prnGSPA.rda")
   
   if (is.null(gset_nms)) {
     if (file.exists(file)) {
@@ -1314,7 +1314,7 @@ match_gset_nms <- function (gset_nms = NULL) {
     stop ("The `gset_nms` is NULL after matching parameters to the latest `prnGSPA(...)`.", 
           "\n\tConsider providing explicitly the `gset_nms`: ", 
           "\n\t\t`gset_nms = \"go_sets\"` or ", 
-          "\n\t\t`gset_nms = \"~\\\\proteoQ\\\\dbs\\\\go_hs.rds\"` ...",
+          "\n\t\t`gset_nms = \"~/proteoQ/dbs/go_hs.rds\"` ...",
           call. = FALSE)
   }
   
@@ -2146,7 +2146,7 @@ count_phosphopeps <- function() {
   
   write.csv(
     data.frame(n_peps = n_phos_peps, n_sites = n_phos_sites), 
-    file.path(dat_dir, "Peptide\\cache", "phos_pep_nums.csv"), 
+    file.path(dat_dir, "Peptide/cache", "phos_pep_nums.csv"), 
     row.names = FALSE
   )
 }
@@ -2154,17 +2154,17 @@ count_phosphopeps <- function() {
 
 #' peptide mis-cleavage counts
 count_pepmiss <- function() {
-  dir.create(file.path(dat_dir, "PSM\\cache"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(dat_dir, "PSM/cache"), recursive = TRUE, showWarnings = FALSE)
   
   rmPSMHeaders()
   
-  filelist = list.files(path = file.path(dat_dir, "PSM\\cache"),
-                        pattern = "^F[0-9]{6}\\_hdr_rm.csv$")
+  filelist <- list.files(path = file.path(dat_dir, "PSM/cache"),
+                        pattern = "^F[0-9]{6}_hdr_rm.csv$")
   
   if (length(filelist) == 0) stop(paste("No PSM files under", file.path(dat_dir, "PSM")))
   
   df <- purrr::map(filelist, ~ {
-    data <- read.delim(file.path(dat_dir, "PSM\\cache", .x), sep = ',', check.names = FALSE, 
+    data <- read.delim(file.path(dat_dir, "PSM/cache", .x), sep = ',', check.names = FALSE, 
                        header = TRUE, stringsAsFactors = FALSE, quote = "\"",fill = TRUE , skip = 0)
     
     data$dat_file <- gsub("_hdr_rm\\.csv", "", .x)
@@ -2177,7 +2177,7 @@ count_pepmiss <- function() {
     tibble::tibble(total = tot, miscleavage = mis, percent = miscleavage/tot)
   }) %>% do.call(rbind, .)
   
-  write.csv(df, file.path(dat_dir, "PSM\\cache\\miscleavage_nums.csv"), row.names = FALSE)
+  write.csv(df, file.path(dat_dir, "PSM/cache/miscleavage_nums.csv"), row.names = FALSE)
 }
 
 
@@ -2321,7 +2321,7 @@ concat_fml_dots <- function(fmls = NULL, fml_nms = NULL, dots = NULL, anal_type 
   if ((!is_empty(fmls)) & (anal_type == "GSEA")) return(c(dots, fmls))
   
   if (purrr::is_empty(fmls)) {
-    fml_file <-  file.path(dat_dir, "Calls\\pepSig_formulas.rda")
+    fml_file <-  file.path(dat_dir, "Calls/pepSig_formulas.rda")
     if (file.exists(fml_file)) {
       load(file = fml_file)
       
@@ -2549,8 +2549,8 @@ ok_existing_params <- function (filepath) {
   
   if (purrr::is_empty(missing_samples)) return(TRUE)
   
-  try(unlink(file.path(dat_dir, "Peptide\\Histogram\\MGKernel_params_[NZ].txt")))
-  try(unlink(file.path(dat_dir, "Protein\\Histogram\\MGKernel_params_[NZ].txt")))
+  try(unlink(file.path(dat_dir, "Peptide/Histogram/MGKernel_params_[NZ].txt")))
+  try(unlink(file.path(dat_dir, "Protein/Histogram/MGKernel_params_[NZ].txt")))
 
   warning(
     "\nThe following entries(s) in `expt_smry.xlsx` are missing from `MGKernel_params` files: \n\t", 

--- a/R/volcanos.R
+++ b/R/volcanos.R
@@ -504,7 +504,7 @@ gsVolcano <- function(df2 = NULL, df = NULL, contrast_groups = NULL,
 	                                                           log2fc = col_double())), 
 	                          error = function(e) NA)
 	
-	message("Secondary file loaded: ", gsub("\\\\", "/", file.path(filepath, fml_nm, df2)))
+	message("Secondary file loaded: ", file.path(filepath, fml_nm, df2))
 
 	filter2_dots <- dots %>% .[purrr::map_lgl(., is.language)] %>% .[grepl("^filter2_", names(.))]
 	arrange2_dots <- dots %>% .[purrr::map_lgl(., is.language)] %>% .[grepl("^arrange2_", names(.))]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 proteoQ
 ================
 true
-2020-06-12
+2020-06-18
 
   - [Introduction to proteoQ](#introduction-to-proteoq)
   - [Installation](#installation)
@@ -11,6 +11,7 @@ true
       - [1.3 PSMs to peptides](#psms-to-peptides)
       - [1.4 Peptides to proteins](#peptides-to-proteins)
       - [1.5 Workflow scripts](#workflow-scripts)
+      - [1.6 Quick start](#quick-start)
   - [2 Basic informatics](#basic-informatics)
       - [2.1 MDS](#mds)
       - [2.2 PCA](#pca)
@@ -124,8 +125,8 @@ corresponding fasta files from the `proteoQDA` to a database folder:
 
 ``` r
 library(proteoQDA)
-copy_refseq_hs("~\\proteoQ\\dbs\\fasta\\refseq")
-copy_refseq_mm("~\\proteoQ\\dbs\\fasta\\refseq")
+copy_refseq_hs("~/proteoQ/dbs/fasta/refseq")
+copy_refseq_mm("~/proteoQ/dbs/fasta/refseq")
 ```
 
 #### 1.1.2 PSM data
@@ -156,7 +157,7 @@ To illustrate, I copy over Mascot PSMs to a working directory,
 `dat_dir`:
 
 ``` r
-dat_dir <- "~\\proteoQ\\examples"
+dat_dir <- "~/proteoQ/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 copy_global_mascot(dat_dir)
 ```
@@ -262,7 +263,7 @@ a work space:
 
 ``` r
 library(proteoQ)
-load_expts("~\\proteoQ\\examples")
+load_expts("~/proteoQ/examples")
 ```
 
 ### 1.2 PSM summarization
@@ -283,8 +284,8 @@ We start the section by processing the PSM files exported directly from
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   rptr_intco = 1000,
   rm_craps = TRUE,
   rm_krts = FALSE,
@@ -1185,6 +1186,28 @@ system.file("extdata", "workflow_base.R", package = "proteoQ")
 Another good place to get started is via the help `?load_expts`. More
 workflow scripts are under construction.
 
+### 1.6 Quick start
+
+For quick demonstrations, steps in data preprocessing can be bypassed:
+
+``` r
+unzip(system.file("extdata", "demo.zip", package = "proteoQDA"), 
+      exdir = "~/proteoq_bypass", overwrite  = FALSE)
+
+# file.exists("~/proteoq_bypass/proteoQ/examples/Peptide/Peptide.txt")
+# file.exists("~/proteoq_bypass/proteoQ/examples/Protein/Protein.txt")
+
+library(proteoQ)
+load_expts("~/proteoq_bypass/proteoQ/examples")
+
+# Exemplary protein MDS
+prnMDS(
+  show_ids = FALSE, 
+  width = 8,
+  height = 4,
+)
+```
+
 ## 2 Basic informatics
 
 In this section I illustrate the following applications of `proteoQ`:
@@ -1549,14 +1572,14 @@ my_theme <- theme_bw() + theme(
 )
 
 p <- ggplot(res$pca) +
-  geom_point(aes(x = Coordinate.1, y = Coordinate.2, colour = Color, shape = Shape, 
+  geom_point(aes(x = PC1, y = PC2, colour = Color, shape = Shape, 
                  alpha = Alpha), size = 4, stroke = 0.02) + 
   scale_y_continuous(breaks = seq(5, 15, by = 5)) + 
-  labs(title = "", x = paste0("PC1 (", res$var[1], ")"), y = paste0("PC2 (", res$var[2], ")")) +
+  labs(title = "", x = paste0("PC1 (", res$prop_var[1], ")"), y = paste0("PC2 (", res$prop_var[2], ")")) +
   coord_fixed() + 
   my_theme
 
-ggsave(file.path(dat_dir, "Protein\\PCA\\nocent_2.png"), width = 6, height = 4)
+ggsave(file.path(dat_dir, "Protein/PCA/nocent_2.png"), width = 6, height = 4)
 ```
 
 <div class="figure" style="text-align: center">
@@ -1928,7 +1951,7 @@ under the file folder `~\\proteoQ\\dbs\\go`:
 ``` r
 prepGO(
   species = human,
-  db_path = "~\\proteoQ\\dbs\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/goa_human.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_hs.rds,
@@ -1936,14 +1959,14 @@ prepGO(
 
 prepGO(
   species = mouse,
-  db_path = "~\\proteoQ\\dbs\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/mgi.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_mm.rds,
 )
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\go", "go_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\go", "go_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/go", "go_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/go", "go_mm.rds")))
 ```
 
 Similarly, we prepare custom `MSig` data bases for `human` and `mouse`:
@@ -1951,7 +1974,7 @@ Similarly, we prepare custom `MSig` data bases for `human` and `mouse`:
 ``` r
 prepMSig(
   # msig_url = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/c2.all.v7.0.entrez.gmt",
-  # db_path = "~\\proteoQ\\dbs\\msig",
+  # db_path = "~/proteoQ/dbs/msig",
   species = human,
   filename = msig_hs.rds,
 )
@@ -1959,13 +1982,13 @@ prepMSig(
 prepMSig(
   # msig_url = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/c2.all.v7.0.entrez.gmt",
   # ortho_mart = mmusculus_gene_ensembl, 
-  # db_path = "~\\proteoQ\\dbs\\msig",  
+  # db_path = "~/proteoQ/dbs/msig",  
   species = mouse,
   filename = msig_mm.rds,
 )
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\msig", "msig_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\msig", "msig_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_mm.rds")))
 ```
 
 We need to provide the list name of `ortho_mart` for species other than
@@ -1977,7 +2000,7 @@ with `prnGSPA` and `gspaMap` for analysis and visualization:
 
 ``` r
 # start over
-unlink(file.path(dat_dir, "Protein\\GSPA"), recursive = TRUE, force = TRUE)
+unlink(file.path(dat_dir, "Protein/GSPA"), recursive = TRUE, force = TRUE)
 
 prnGSPA(
   impute_na = FALSE,
@@ -1985,17 +2008,17 @@ prnGSPA(
   logFC_cutoff = log2(1.2),
   gspval_cutoff = 5E-2,
   gslogFC_cutoff = log2(1.2), 
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_hs.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds", 
+               "~/proteoQ/dbs/msig/msig_hs.rds", 
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
 )
 
 gspaMap(
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_hs.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds", 
+               "~/proteoQ/dbs/msig/msig_hs.rds", 
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
   impute_na = FALSE,
   show_labels = FALSE, 
   gspval_cutoff = 5E-2, 
@@ -2485,7 +2508,7 @@ of protein-protein interactions. More details can be found from
 
 ``` r
 anal_prnString(
-  db_path = "~\\proteoQ\\dbs\\string",
+  db_path = "~/proteoQ/dbs/string",
   score_cutoff = .9,
   filter_by_sp = exprs(species %in% c("human", "mouse")), 
   filter_prots_by = exprs(prot_n_pep >= 2),
@@ -2503,7 +2526,7 @@ download separately the databases for a given `species`:
 ``` r
 dl_stringdbs(
   species = rat,
-  db_path = "~\\proteoQ\\dbs\\string", 
+  db_path = "~/proteoQ/dbs/string", 
 )
 ```
 
@@ -2529,7 +2552,7 @@ peptide `log2FC`.
 
 ``` r
 # exemplary data
-temp_dir <- "~\\proteoQ\\ref_w2"
+temp_dir <- "~/proteoQ/ref_w2"
 dir.create(temp_dir, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -2544,8 +2567,8 @@ load_expts(temp_dir, expt_smry_ref_w2.xlsx)
 normPSM(
   group_psm_by = pep_seq,
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   rptr_intco = 1000,
   rm_craps = TRUE,
   rm_krts = FALSE,
@@ -2596,7 +2619,7 @@ of the `WHIM2` and the `WHIM16` proteomes. We next perform analogously
 the data summary and histogram visualization.
 
 ``` r
-temp_dir_w2w16 <- "~\\proteoQ\\ref_w2w16"
+temp_dir_w2w16 <- "~/proteoQ/ref_w2w16"
 dir.create(temp_dir_w2w16, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -2610,8 +2633,8 @@ load_expts(temp_dir_w2w16, expt_smry_ref_w2_w16.xlsx)
 normPSM(
   group_psm_by = pep_seq,
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   rptr_intco = 1000,
   rm_craps = TRUE,
   rm_krts = FALSE,
@@ -2662,7 +2685,7 @@ S1C**):
 ``` r
 # continue on the `ref_w2` example in section 3.1.1
 library(proteoQ)
-load_expts("~\\proteoQ\\ref_w2", expt_smry_ref_w2.xlsx, frac_smry.xlsx)
+load_expts("~/proteoQ/ref_w2", expt_smry_ref_w2.xlsx, frac_smry.xlsx)
 
 # `BI_1` subset for visualization
 purgePep(
@@ -2751,7 +2774,7 @@ the `BI_1` subset.
 
 ``` r
 # exemplary data
-dat_dir <- "~\\proteoQ\\phospho_stoichiometry"
+dat_dir <- "~/proteoQ/phospho_stoichiometry"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -2768,8 +2791,8 @@ load_expts()
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   filter_peps = exprs(pep_expect <= .1), 
 )
 
@@ -2946,7 +2969,7 @@ filtration during heat map visualization.
 
 ``` r
 # add a column to "Protein.txt"
-df <- readr::read_tsv(file.path(dat_dir, "Protein\\Protein.txt")) 
+df <- readr::read_tsv(file.path(dat_dir, "Protein/Protein.txt")) 
 
 library(magrittr)
 n_not_na <- df %>% 
@@ -2959,7 +2982,7 @@ n_not_na <- df %>%
 df %>% 
   dplyr::mutate(n_not_na = n_not_na) %>% 
   # proteoQ::reorderCols2() %>% 
-  readr::write_tsv(file.path(dat_dir, "Protein\\Protein.txt"))
+  readr::write_tsv(file.path(dat_dir, "Protein/Protein.txt"))
 ```
 
 Note that there is a restriction in column additions in that the custom
@@ -2970,7 +2993,7 @@ visualization:
 
 ``` r
 prnHM(
-  df = "Protein\\Protein.txt", 
+  df = "Protein/Protein.txt", 
   xmin = -1,
   xmax = 1,
   xmargin = 0.1,
@@ -2990,7 +3013,7 @@ prnHM(
 ```
 
 Importantly, we need to supply the file name to argument `df`. This is
-because a higher precedence will be given to `Model\\Protein_pVals.txt`
+because a higher precedence will be given to `Model/Protein_pVals.txt`
 over `Protein.txt`. Without specifying the value of `df`, proteoQ will
 look for the `n_not_na` column that are indeed absent from
 `Protein_pVals.txt`.
@@ -3010,7 +3033,7 @@ look for the `n_not_na` column that are indeed absent from
 Alternatively, we may add the custom column to `Protein_pVals.txt`:
 
 ``` r
-df <- readr::read_tsv(file.path(dat_dir, "Protein\\Model\\Protein_pVals.txt")) 
+df <- readr::read_tsv(file.path(dat_dir, "Protein/Model/Protein_pVals.txt")) 
 
 n_not_na <- df %>% 
   dplyr::select(grep("Z_log2_R", names(.))) %>% 
@@ -3021,10 +3044,10 @@ n_not_na <- df %>%
 
 df %>% 
   dplyr::mutate(na_counts = na_counts) %>% 
-  readr::write_tsv(file.path(dat_dir, "Protein\\Model\\Protein_pVals.txt"))
+  readr::write_tsv(file.path(dat_dir, "Protein/Model/Protein_pVals.txt"))
 
 prnHM(
-  df = "Protein\\Model\\Protein_pVals.txt", 
+  df = "Protein/Model/Protein_pVals.txt", 
   xmin = -1,
   xmax = 1,
   xmargin = 0.1,
@@ -3069,7 +3092,7 @@ We start off by (re)executing the reduced example shown in
 `?load_expts`:
 
 ``` r
-dat_dir <- "~\\proteoQ\\randeffs\\examples"
+dat_dir <- "~/proteoQ/randeffs/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -3084,8 +3107,8 @@ normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
   annot_kinases = TRUE, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
 )
 
 PSM2Pep()
@@ -3169,7 +3192,7 @@ prnSig(
 )
 
 # correlation plots
-read.csv(file.path(dat_dir, "Protein\\Model\\Protein_pVals.txt"), 
+read.csv(file.path(dat_dir, "Protein/Model/Protein_pVals.txt"), 
          check.names = FALSE, header = TRUE, sep = "\t") %>%
   dplyr::select(grep("pVal\\s+", names(.))) %>% 
   `colnames<-`(c("none", "one", "two")) %>% 

--- a/data-raw/annotProteinAccession.R
+++ b/data-raw/annotProteinAccession.R
@@ -195,5 +195,9 @@ foo_combine_codes <- function (filepath = file.path("C:/Results/R/proteoQ/R")) {
 }
 
 
-
+# zipped base protein.txt, peptide.txt and call pars
+foo_zip <- function () {
+  zip("my.zip", "C:/proteoQ/examples")
+  unzip("./my.zip", exdir = "~/proteoQ_demo", overwrite  = FALSE)
+}
 

--- a/data-raw/annotProteinAccession.R
+++ b/data-raw/annotProteinAccession.R
@@ -68,7 +68,7 @@ taxid_lookup <- function(species) {
 
 # a case of same GO term but different species
 # add species name to GO data sets
-devtools::document("c:\\results\\r\\proteoq")
+devtools::document("c:/results/r/proteoq")
 species <- "rat"
 abbr_sp <- purrr::map_chr(species, sp_lookup)
 filename <- paste0("go_sets_", abbr_sp)
@@ -79,7 +79,7 @@ if (!grepl(paste0("^", abbr_sp), temp[1])) {
   temp <- temp %>% 
     `names<-`(paste(abbr_sp, names(.), sep = "_"))
   assign(filename, temp)
-  save(list = filename, file = file.path("C:\\Results\\R\\proteoQ\\data", paste0(filename, ".RData")))
+  save(list = filename, file = file.path("C:/Results/R/proteoQ/data", paste0(filename, ".RData")))
 }
 
 # new_name <- paste0("go_sets_", abbr_species_lwr)
@@ -116,7 +116,7 @@ if (!grepl(paste0("^", abbr_sp), temp[1])) {
 
 
 # ----------------------------------------------
-devtools::document(pkg  = "C:\\Results\\R\\proteoQ")
+devtools::document(pkg  = "C:/Results/R/proteoQ")
 kinase_lookup <- kinase_lookup %>% 
 					dplyr::rename(
 						refseq_acc = REFSEQ_PROTEIN, 
@@ -137,7 +137,7 @@ kinase_lookup <- kinase_lookup %>%
 					)
 
 filename <- "kinase_lookup"
-save(list = filename, file = file.path("C:\\Results\\R\\proteoQ\\data", paste0(filename, ".rda")), compress = "xz")
+save(list = filename, file = file.path("C:/Results/R/proteoQ/data", paste0(filename, ".rda")), compress = "xz")
 
 	
 
@@ -183,15 +183,15 @@ map_refseq <- function(species) {
 
 
 # combine all .R files into one
-# foo_combine_codes(filepath = file.path("C:\\Results\\R\\proteoQ\\inst\\extdata\\examples"))
-foo_combine_codes <- function (filepath = file.path("C:\\Results\\R\\proteoQ\\R")) {
+# foo_combine_codes(filepath = file.path("C:/Results/R/proteoQ/inst/extdata/examples"))
+foo_combine_codes <- function (filepath = file.path("C:/Results/R/proteoQ/R")) {
   filenames <- dir(filepath, pattern = ".R$")
   
   dir.create(file.path(filepath, "temp"))
   
   purrr::map(file.path(filepath, filenames), readLines) %>% 
     purrr::reduce(`c`, init = NULL) %>% 
-    writeLines(file.path(filepath, "temp\\all.R"))  
+    writeLines(file.path(filepath, "temp/all.R"))  
 }
 
 

--- a/inst/extdata/examples/load_expts_.R
+++ b/inst/extdata/examples/load_expts_.R
@@ -4,13 +4,13 @@
 # ===================================
 # fasta (all platforms)
 library(proteoQDA)
-fasta_dir <- "~\\proteoQ\\dbs\\fasta\\refseq"
+fasta_dir <- "~/proteoQ/dbs/fasta/refseq"
 dir.create(fasta_dir, recursive = TRUE, showWarnings = FALSE)
 copy_refseq_hs(fasta_dir)
 copy_refseq_mm(fasta_dir)
 
 # working directory (all platforms)
-dat_dir <- "~\\proteoQ\\examples"
+dat_dir <- "~/proteoQ/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 # metadata (all platforms)
@@ -35,7 +35,7 @@ if (!choose_one) {
 # PSM, peptide and protein processing
 # ===================================
 library(proteoQ)
-load_expts("~\\proteoQ\\examples")
+load_expts("~/proteoQ/examples")
 
 # PSM data standardization
 normPSM(
@@ -45,8 +45,8 @@ normPSM(
   annot_kinases = TRUE, 
   
   # no default and required
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
 )
 
 # optional PSM purging
@@ -119,13 +119,13 @@ prnSig(impute_na = TRUE)
 }
 
 \dontrun{
-load_expts(dat_dir = "~\\proteoQ\\examples", expt_smry = "expt_smry.xlsx")
+load_expts(dat_dir = "~/proteoQ/examples", expt_smry = "expt_smry.xlsx")
 
 # not working; `expt_smry = my_expt` is an expression
 my_expt <- "expt_smry.xlsx"
-load_expts(dat_dir = "~\\proteoQ\\examples", expt_smry = my_expt)
+load_expts(dat_dir = "~/proteoQ/examples", expt_smry = my_expt)
 
 # need unquoting; 
 # see also: https://dplyr.tidyverse.org/articles/programming.html
-load_expts(dat_dir = "~\\proteoQ\\examples", expt_smry = !!my_expt)
+load_expts(dat_dir = "~/proteoQ/examples", expt_smry = !!my_expt)
 }

--- a/inst/extdata/examples/normPSM_.R
+++ b/inst/extdata/examples/normPSM_.R
@@ -10,8 +10,8 @@
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = prot_acc,
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   
   # variable argument statement(s)
   filter_psms_at = exprs(pep_expect <= .1),
@@ -22,8 +22,8 @@ normPSM(
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = prot_acc,
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   corrected_int = TRUE,
   rm_reverses = TRUE,
   
@@ -35,8 +35,8 @@ normPSM(
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = prot_acc,
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   
   # vararg statement(s)
   filter_psms = exprs(score >= 10),
@@ -67,28 +67,28 @@ Ref2Entrez(species = mouse)
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\proteoQ\\dbs\\entrez\\refseq_entrez_hs.rds", 
-             "~\\proteoQ\\dbs\\entrez\\refseq_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/refseq_entrez_mm.rds"),
 )
 
 
 ## Not run: 
 # wrong fasta 
 normPSM(
-  fasta = "~\\proteoQ\\dbs\\fasta\\wrong.fasta",
+  fasta = "~/proteoQ/dbs/fasta/wrong.fasta",
 )
 
 # no mouse entry annotation
 normPSM(
-  fasta = "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
+  fasta = "~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
 )
 
 # bad vararg statement
 normPSM(
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   filter_psms_at = exprs(column_key_not_in_psm_tables <= .1),
 )
 ## End(Not run)

--- a/inst/extdata/examples/normPep_.R
+++ b/inst/extdata/examples/normPep_.R
@@ -210,7 +210,7 @@ pepHist(scale_log2r = TRUE, col_select = BI_1, filename = mc.png)
 pepHist(scale_log2r = TRUE, col_select = BI_1, filter_ = exprs(gene == "GAPDH"), filename = mcGAPDH.png)
 
 # heat map for `BI_1` samples
-# (outputs under `Peptide\Heatmap` folder; for help, ?pepHM)
+# (outputs under `Peptide/Heatmap` folder; for help, ?pepHM)
 pepHM(
   col_select = BI_1, 
   xmin = -2,

--- a/inst/extdata/examples/normPrn_.R
+++ b/inst/extdata/examples/normPrn_.R
@@ -213,7 +213,7 @@ prnHist(scale_log2r = TRUE, col_select = BI_1, filename = mc.png)
 prnHist(scale_log2r = TRUE, col_select = BI_1, filter_ = exprs(gene == "GAPDH"), filename = mcGAPDH.png)
 
 # heat map
-# (outputs under `Protein\Heatmap` folder; for help, ?pepHM)
+# (outputs under `Protein/Heatmap` folder; for help, ?pepHM)
 prnHM(
   col_select = BI_1, 
   xmin = -2,

--- a/inst/extdata/examples/prepEntrez_.R
+++ b/inst/extdata/examples/prepEntrez_.R
@@ -12,12 +12,12 @@ BiocManager::install("org.Mm.eg.db")
 
 # Prep II: set up RefSeq Fasta(s) if not yet
 library(proteoQDA)
-db_path <- "~\\proteoQ\\dbs\\fasta\\refseq"
+db_path <- "~/proteoQ/dbs/fasta/refseq"
 copy_refseq_hs(db_path)
 copy_refseq_mm(db_path)
 
 # Prep III: copy metadata and PSMs if not yet
-dat_dir <- "~\\proteoQ\\custom_refseq_lookups"
+dat_dir <- "~/proteoQ/custom_refseq_lookups"
 copy_global_exptsmry(dat_dir)
 copy_global_fracsmry(dat_dir)
 
@@ -28,36 +28,36 @@ copy_global_mascot(dat_dir)
 
 # --- workflow begins ---
 library(proteoQ)
-dat_dir <- "~\\proteoQ\\custom_refseq_lookups"
+dat_dir <- "~/proteoQ/custom_refseq_lookups"
 load_expts()
 
 # prepare RefSeq-to-Entrez lookups
 Ref2Entrez(species = human)
 Ref2Entrez(species = mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\refseq_entrez_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\refseq_entrez_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/refseq_entrez_mm.rds")))
 
 # overrule the default `Entrez` lookups with the custom databases
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\proteoQ\\dbs\\entrez\\refseq_entrez_hs.rds", 
-             "~\\proteoQ\\dbs\\entrez\\refseq_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/refseq_entrez_mm.rds"),
 )
 
 
 ## A UniProt example
 # Prep I: set up UniProt Fasta(s) if not yet
 library(proteoQDA)
-db_path <- "~\\proteoQ\\dbs\\fasta\\uniprot"
+db_path <- "~/proteoQ/dbs/fasta/uniprot"
 copy_uniprot_hs(db_path)
 copy_uniprot_mm(db_path)
 
 # Prep II: copy metadata and PSMs if not yet
-dat_dir <- "~\\proteoQ\\custom_uniprot_lookups"
+dat_dir <- "~/proteoQ/custom_uniprot_lookups"
 copy_global_exptsmry(dat_dir)
 copy_global_fracsmry(dat_dir)
 
@@ -73,23 +73,23 @@ simulUniprotPSM(MaxQuant)
 
 # --- workflow begins ---
 library(proteoQ)
-dat_dir <- "~\\proteoQ\\custom_uniprot_lookups"
+dat_dir <- "~/proteoQ/custom_uniprot_lookups"
 load_expts()
 
 # prepare UniProt-to-Entrez lookups
 Uni2Entrez(species = human)
 Uni2Entrez(species = mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/uniprot_entrez_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/uniprot_entrez_mm.rds")))
 
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\uniprot\\uniprot_hs_2014_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\uniprot\\uniprot_mm_2014_07.fasta"),
-  entrez = c("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_hs.rds", 
-             "~\\proteoQ\\dbs\\entrez\\uniprot_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/uniprot/uniprot_hs_2014_07.fasta",
+            "~/proteoQ/dbs/fasta/uniprot/uniprot_mm_2014_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/uniprot_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/uniprot_entrez_mm.rds"),
 )
 }
 
@@ -99,18 +99,18 @@ normPSM(
 Uni2Entrez(species = this_human, abbr_species = Hs, filename = my_human.rds)
 Uni2Entrez(species = this_mouse, abbr_species = Mm, filename = my_mouse.rds)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\my_human.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\my_mouse.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/my_human.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/my_mouse.rds")))
 
 # in PSM and subsequent outputs, values under column `species` 
 #  will be shown as "this_human" or "this_mouse"
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\proteoQ\\dbs\\entrez\\my_human.rds", 
-             "~\\proteoQ\\dbs\\entrez\\my_mouse.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/my_human.rds", 
+             "~/proteoQ/dbs/entrez/my_mouse.rds"),
 )  
 }
 
@@ -127,8 +127,8 @@ Uni2Entrez(species = "worm", abbr_species = "Ce", filename = uniprot_entrez_ce.r
 # --- PAUSE: prepare Fasta file(s) before proceeding to `normPSM`. ---
 
 normPSM(
-  fasta = "~\\proteoQ\\dbs\\fasta\\specify_your_worm.fasta",
-  entrez = c("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_ce.rds"),
+  fasta = "~/proteoQ/dbs/fasta/specify_your_worm.fasta",
+  entrez = c("~/proteoQ/dbs/entrez/uniprot_entrez_ce.rds"),
 )
 }
 

--- a/inst/extdata/examples/prnGSPA_.R
+++ b/inst/extdata/examples/prnGSPA_.R
@@ -218,12 +218,12 @@ prnGSPAHM(
 # custom GO databases
 # ===================================
 # start over
-unlink(file.path(dat_dir, "Protein\\GSPA"), recursive = TRUE, force = TRUE)
+unlink(file.path(dat_dir, "Protein/GSPA"), recursive = TRUE, force = TRUE)
 
 # prepare GO databases (see also ?prepGO)
 prepGO(
   species = human,
-  db_path = "~\\proteoQ\\dbs\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/goa_human.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_hs.rds,
@@ -231,28 +231,28 @@ prepGO(
 
 prepGO(
   species = mouse,
-  db_path = "~\\proteoQ\\dbs\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/mgi.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_mm.rds,
 )
 
-head(readRDS(file.path("~\\proteoQ\\dbs\\go", "go_hs.rds")))
-head(readRDS(file.path("~\\proteoQ\\dbs\\go", "go_mm.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/go", "go_hs.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/go", "go_mm.rds")))
 
 # analysis
 prnGSPA(
   impute_na = FALSE,
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
 )
 
 # It is possible that the system "go_sets" may be partially different to the
 # custom GO. Be explicit on `gset_nms`; otherwise, the default of `gset_nms =
 # c("go_sets", "c2_msig")` will be applied.
 gspaMap(
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
   impute_na = FALSE,
   topn = 20, 
   show_sig = pVal, 
@@ -262,28 +262,28 @@ gspaMap(
 # custom MSig databases
 # ===================================
 # start over
-unlink(file.path(dat_dir, "Protein\\GSPA"), recursive = TRUE, force = TRUE)
+unlink(file.path(dat_dir, "Protein/GSPA"), recursive = TRUE, force = TRUE)
 
 # prepare MSig databases (see also ?prepMSig)
 prepMSig(species = human)
 prepMSig(species = mouse)
 
-head(readRDS(file.path("~\\proteoQ\\dbs\\msig", "msig_hs.rds")))
-head(readRDS(file.path("~\\proteoQ\\dbs\\msig", "msig_mm.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_hs.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_mm.rds")))
 
 # analysis
 prnGSPA(
   impute_na = FALSE,
-  gset_nms = c("~\\proteoQ\\dbs\\msig\\msig_hs.rds",
-               "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/msig/msig_hs.rds",
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
 )
 
 # It is possible that the system "c2_msig" may be partially different to the
 # custom databases. Be explicit on `gset_nms`; otherwise, the default of
 # `gset_nms = c("go_sets", "c2_msig")` will be applied.
 gspaMap(
-  gset_nms = c("~\\proteoQ\\dbs\\msig\\msig_hs.rds",
-               "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/msig/msig_hs.rds",
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
   impute_na = FALSE,
   topn = 20, 
   show_sig = pVal, 
@@ -291,8 +291,8 @@ gspaMap(
 
 ## put custom `prepGO`, `prepMSig` preparation into `prnGSPA` analysis
 # start over with fresh database preparation
-unlink(file.path("~\\proteoQ\\dbs\\go"), recursive = TRUE, force = TRUE)
-unlink(file.path("~\\proteoQ\\dbs\\msig"), recursive = TRUE, force = TRUE)
+unlink(file.path("~/proteoQ/dbs/go"), recursive = TRUE, force = TRUE)
+unlink(file.path("~/proteoQ/dbs/msig"), recursive = TRUE, force = TRUE)
 
 library(magrittr)
 

--- a/inst/extdata/examples/prnGSVA_.R
+++ b/inst/extdata/examples/prnGSVA_.R
@@ -97,7 +97,7 @@ prnGSVA(
   verbose = FALSE,
   parallel.sz = 0,
   mx.diff = TRUE,
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
 )
 }

--- a/inst/extdata/examples/prnHist_.R
+++ b/inst/extdata/examples/prnHist_.R
@@ -135,7 +135,7 @@ p <- p +
 
 p <- p + geom_vline(xintercept = 0, size = .25, linetype = "dashed")
 
-ggsave(file.path(dat_dir, "Peptide\\Histogram\\my_ggplot2.png"), 
+ggsave(file.path(dat_dir, "Peptide/Histogram/my_ggplot2.png"), 
        width = 22, height = 48, limitsize = FALSE)
 
 \dontrun{

--- a/inst/extdata/examples/prnMDS_.R
+++ b/inst/extdata/examples/prnMDS_.R
@@ -179,7 +179,7 @@ p <- ggplot(res) +
   coord_fixed() + 
   geom_text(aes(x = Coordinate.1, y = Coordinate.2, label = Sample_ID), color = "gray", size = 1)
 
-ggsave(file.path(dat_dir, "Protein\\MDS\\my_ggplot2.png"))
+ggsave(file.path(dat_dir, "Protein/MDS/my_ggplot2.png"))
 
 
 \dontrun{

--- a/inst/extdata/examples/prnMDS_.R
+++ b/inst/extdata/examples/prnMDS_.R
@@ -172,15 +172,22 @@ pepMDS(
 library(ggplot2)
 res <- prnMDS(filename = foo.png)
 
-p <- ggplot(res) +
-  geom_point(aes(x = Coordinate.1, y = Coordinate.2, colour = Color, shape = Shape, alpha = Alpha), 
-             size = 4, stroke = 0.02) + 
-  labs(title = "", x = expression("Coordinate 1"), y = expression("Coordinate 2")) +
+p <- ggplot(res, aes(x = Coordinate.1, y = Coordinate.2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(colour = Shape), linetype = 2) + 
+  labs(title = "", x = "Coordinate 1", y = "Coordinate 2") +
   coord_fixed() + 
   geom_text(aes(x = Coordinate.1, y = Coordinate.2, label = Sample_ID), color = "gray", size = 1)
 
 ggsave(file.path(dat_dir, "Protein/MDS/my_ggplot2.png"))
 
+p_fil <- ggplot(res, aes(x = Coordinate.1, y = Coordinate.2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(fill = Shape), geom = "polygon", alpha = .4) + 
+  labs(title = "", x = "Coordinate 1", y = "Coordinate 2") +
+  coord_fixed() 
+
+ggsave(file.path(dat_dir, "Protein/MDS/my_ggplot2_fil.png"))
 
 \dontrun{
 prnMDS(

--- a/inst/extdata/examples/prnPCA_.R
+++ b/inst/extdata/examples/prnPCA_.R
@@ -11,7 +11,7 @@ scale_log2r <- TRUE
 # peptides, all samples
 pepPCA(
   col_select = Select, 
-  filter_peps_by = exprs(pep_n_psm >= 10),
+  filter_peps_by = exprs(pep_n_psm >= 3),
   show_ids = FALSE, 
   filename = "peps_rowfil.png",
 )
@@ -196,14 +196,26 @@ res <- prnPCA(filename = foo.png)
 
 # names(res)
 
-p <- ggplot(res$pca) +
-  geom_point(aes(x = PC1, y = PC2, colour = Color, shape = Shape, alpha = Alpha), 
-             size = 4, stroke = 0.02) + 
-  labs(title = "", x = paste0("PC1 (", res$var[1], ")"), y = paste0("PC2 (", res$var[2], ")")) +
+p <- ggplot(res$pca, aes(x = PC1, y = PC2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(colour = Shape), linetype = 2) + 
+  labs(title = "", 
+       x = paste0("PC1 (", res$prop_var[1], ")"), 
+       y = paste0("PC2 (", res$prop_var[2], ")")) +
   coord_fixed() + 
-  geom_text(aes(x = PC1, y = PC2, label = Sample_ID), color = "gray", size = 1)
+  geom_text(aes(label = Sample_ID), color = "gray", size = 1)
 
 ggsave(file.path(dat_dir, "Protein/PCA/my_ggplot2.png"))
+
+p_fil <- ggplot(res$pca, aes(PC1, PC2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(fill = Shape), geom = "polygon", alpha = .4) + 
+  labs(title = "", 
+       x = paste0("PC1 (", res$prop_var[1], ")"), 
+       y = paste0("PC2 (", res$prop_var[2], ")")) +
+  coord_fixed() 
+
+ggsave(file.path(dat_dir, "Protein/PCA/my_ggplot2_fil.png"))
 
 \dontrun{
 prnPCA(

--- a/inst/extdata/examples/prnPCA_.R
+++ b/inst/extdata/examples/prnPCA_.R
@@ -203,7 +203,7 @@ p <- ggplot(res$pca) +
   coord_fixed() + 
   geom_text(aes(x = PC1, y = PC2, label = Sample_ID), color = "gray", size = 1)
 
-ggsave(file.path(dat_dir, "Protein\\PCA\\my_ggplot2.png"))
+ggsave(file.path(dat_dir, "Protein/PCA/my_ggplot2.png"))
 
 \dontrun{
 prnPCA(

--- a/inst/extdata/examples/prnString_.R
+++ b/inst/extdata/examples/prnString_.R
@@ -31,16 +31,16 @@ prepString(
 
 \dontrun{
 identical(
-  readRDS(file.path("~\\proteoQ\\dbs\\string\\string_hs.rds")), 
-  readRDS(file.path("~\\proteoQ\\dbs\\string\\my_hs.rds"))
+  readRDS(file.path("~/proteoQ/dbs/string/string_hs.rds")), 
+  readRDS(file.path("~/proteoQ/dbs/string/my_hs.rds"))
 )
 }
 
 \donttest{
 # analysis: both `human` and `mouse`
 anal_prnString(
-  db_nms = c("~\\proteoQ\\dbs\\string\\string_hs.rds",
-             "~\\proteoQ\\dbs\\string\\string_mm.rds"),
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds"),
   score_cutoff = .9,
   filter_prots_by = exprs(prot_n_pep >= 2),
 )
@@ -49,8 +49,8 @@ anal_prnString(
 # `human` only ('unknown' species will be removed)
 # OK to include both `string_hs.rds` and `string_mm.rds`
 anal_prnString(
-  db_nms = c("~\\proteoQ\\dbs\\string\\string_hs.rds",
-             "~\\proteoQ\\dbs\\string\\string_mm.rds"),
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds"),
   score_cutoff = .9,
   filter_by_sp = exprs(species == "human"),
   filter_prots_by = exprs(prot_n_pep >= 2),
@@ -59,8 +59,8 @@ anal_prnString(
 
 # `mouse` only
 anal_prnString(
-  db_nms = c("~\\proteoQ\\dbs\\string\\string_hs.rds",
-             "~\\proteoQ\\dbs\\string\\string_mm.rds"),
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds"),
   score_cutoff = .9,
   filter_by_sp = exprs(species == "mouse"),
   filter_prots_by = exprs(prot_n_pep >= 2),
@@ -71,7 +71,7 @@ anal_prnString(
 # additional filtration by `pVals` and `log2FC`; 
 # `W16_vs_W2.pVal (W16-W2)` is a column key in `Protein_pVals.txt`
 anal_prnString(
-  db_nms = "~\\proteoQ\\dbs\\string\\string_hs.rds",
+  db_nms = "~/proteoQ/dbs/string/string_hs.rds",
   score_cutoff = .9,
   filter_by_sp = exprs(species == "human", 
                        `W16_vs_W2.pVal (W16-W2)` <= 1E-6,
@@ -81,7 +81,7 @@ anal_prnString(
 )
 
 anal_prnString(
-  db_nms = "~\\proteoQ\\dbs\\string\\string_mm.rds",
+  db_nms = "~/proteoQ/dbs/string/string_mm.rds",
   score_cutoff = .9,
   filter_by_sp = exprs(species == "mouse", 
                        `W16_vs_W2.pVal (W16-W2)` <= 1E-6,

--- a/inst/extdata/mascot_scripts.R
+++ b/inst/extdata/mascot_scripts.R
@@ -16,11 +16,11 @@ devtools::install_github("qzhang503/proteoQDA")
 library(proteoQDA)
 
 # FASTA (all platforms)
-copy_refseq_hs("~\\proteoQ\\dbs\\fasta\\refseq")
-copy_refseq_mm("~\\proteoQ\\dbs\\fasta\\refseq")
+copy_refseq_hs("~/proteoQ/dbs/fasta/refseq")
+copy_refseq_mm("~/proteoQ/dbs/fasta/refseq")
 
 # PSM data (choose one of the platforms)
-dat_dir <- "~\\proteoQ\\examples"
+dat_dir <- "~/proteoQ/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 choose_one <- TRUE
@@ -51,8 +51,8 @@ load_expts(dat_dir)
 normPSM(
 	group_psm_by = pep_seq_mod, 
 	group_pep_by = gene, 
-	fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-						"~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+	fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+						"~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
 	rptr_intco = 1000,
 	rm_craps = TRUE,
 	rm_krts = FALSE,
@@ -70,8 +70,8 @@ if (!dontrun) {
   normPSM(
     group_psm_by = pep_seq_mod, 
     group_pep_by = gene, 
-    fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-              "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+    fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+              "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
     rptr_intco = 1000,
     rm_craps = TRUE,
     rm_krts = FALSE,
@@ -88,8 +88,8 @@ if (!dontrun) {
 	normPSM(
 		group_psm_by = pep_seq, 
 		group_pep_by = gene, 
-		fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-							"~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+		fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+							"~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
 		rptr_intco = 1000,
 		rm_craps = TRUE,
 		rm_krts = FALSE,
@@ -779,7 +779,7 @@ if (!dontrun) {
 ## END of DO NOT RUN
 
 ### STRING database
-string_dir <- "~\\proteoQ\\dbs\\string"
+string_dir <- "~/proteoQ/dbs/string"
 dir.create(string_dir, recursive = TRUE, showWarnings = FALSE)
 
 # download

--- a/inst/extdata/workflow_base.R
+++ b/inst/extdata/workflow_base.R
@@ -215,18 +215,22 @@ prnPCA(
 
 ### correlation
 # peptide logFC, PNNL subset with sample-order supervision
-pepCorr_logFC(
+res <- pepCorr_logFC(
 	col_select = PNNL,
 	col_order = Order, 
 	filename = pnnl_ord.png
 )
 
+# head(res)
+
 # protein logFC, WHIM2 subset with supervision
-prnCorr_logFC(
+res <- prnCorr_logFC(
 	col_select = W2,
 	col_order = Group,
 	filename = w2_ord.png,
 )
+
+# head(res)
 
 ### heat map
 # protein, human subset with row-clustering and subtrees
@@ -276,6 +280,14 @@ anal_prnTrend(
 # protein visualization, sample-order supervision
 plot_prnTrend(
   col_order = Order,
+)
+
+# Make sure that Cytoscape is open.
+# Also note that "Protein_Trend_Z_nclust5.txt" is a secondary data file.
+cluego(
+  df2 = Protein_Trend_Z_nclust5.txt, 
+  species = c(human = "Homo Sapiens"), 
+  n_clust = c(3, 5)
 )
 
 ### NMF

--- a/inst/extdata/workflow_base.R
+++ b/inst/extdata/workflow_base.R
@@ -12,11 +12,11 @@ devtools::install_github("qzhang503/proteoQ")
 library(proteoQDA)
 
 # FASTA (all platforms)
-copy_refseq_hs("~\\proteoQ\\dbs\\fasta\\refseq")
-copy_refseq_mm("~\\proteoQ\\dbs\\fasta\\refseq")
+copy_refseq_hs("~/proteoQ/dbs/fasta/refseq")
+copy_refseq_mm("~/proteoQ/dbs/fasta/refseq")
 
 # PSM data (choose one of the platforms)
-dat_dir <- "~\\proteoQ\\examples"
+dat_dir <- "~/proteoQ/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 choose_one <- TRUE
@@ -41,14 +41,14 @@ copy_global_fracsmry(dat_dir)
 # ==============================================
 # metadata to workspace
 library(proteoQ)
-load_expts("~\\proteoQ\\examples")
+load_expts("~/proteoQ/examples")
 
 # PSM standardization
 normPSM(
 	group_psm_by = pep_seq_mod, 
 	group_pep_by = gene, 
-	fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-						"~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+	fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+	          "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
 	rptr_intco = 1000,
 	rm_craps = TRUE,
 	rm_krts = FALSE,

--- a/man/Pep2Prn.Rd
+++ b/man/Pep2Prn.Rd
@@ -37,7 +37,7 @@ with \code{Mascot} workflows. The statement of \code{filter_peps_at =
 exprs(pep_len <= 50)} will remove peptide entries with \code{pep_len > 50}.}
 }
 \value{
-The primary output in "\code{...\\Protein\\Protein.txt}".
+The primary output in "\code{.../Protein/Protein.txt}".
 }
 \description{
 \code{Pep2Prn} summarizes \code{Peptide.txt} to an interim protein report in

--- a/man/Uni2Entrez.Rd
+++ b/man/Uni2Entrez.Rd
@@ -9,7 +9,7 @@ Uni2Entrez(
   species = "human",
   abbr_species = NULL,
   filename = NULL,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\entrez",
+  db_path = "~/proteoQ/dbs/entrez",
   overwrite = FALSE
 )
 
@@ -17,7 +17,7 @@ Ref2Entrez(
   species = "human",
   abbr_species = NULL,
   filename = NULL,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\entrez",
+  db_path = "~/proteoQ/dbs/entrez",
   overwrite = FALSE
 )
 }
@@ -42,7 +42,7 @@ default, the name will be determined automatically at a given
 saved as a \code{.rds} object for uses with \code{\link{prnGSPA}}.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\entrez"}.}
+is \code{"~/proteoQ/dbs/entrez"}.}
 
 \item{overwrite}{Logical; if TRUE, overwrite the downloaded database(s). The
 default is FALSE.}
@@ -79,12 +79,12 @@ BiocManager::install("org.Mm.eg.db")
 
 # Prep II: set up RefSeq Fasta(s) if not yet
 library(proteoQDA)
-db_path <- "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq"
+db_path <- "~/proteoQ/dbs/fasta/refseq"
 copy_refseq_hs(db_path)
 copy_refseq_mm(db_path)
 
 # Prep III: copy metadata and PSMs if not yet
-dat_dir <- "~\\\\proteoQ\\\\custom_refseq_lookups"
+dat_dir <- "~/proteoQ/custom_refseq_lookups"
 copy_global_exptsmry(dat_dir)
 copy_global_fracsmry(dat_dir)
 
@@ -95,36 +95,36 @@ copy_global_mascot(dat_dir)
 
 # --- workflow begins ---
 library(proteoQ)
-dat_dir <- "~\\\\proteoQ\\\\custom_refseq_lookups"
+dat_dir <- "~/proteoQ/custom_refseq_lookups"
 load_expts()
 
 # prepare RefSeq-to-Entrez lookups
 Ref2Entrez(species = human)
 Ref2Entrez(species = mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\refseq_entrez_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\refseq_entrez_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/refseq_entrez_mm.rds")))
 
 # overrule the default `Entrez` lookups with the custom databases
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\refseq_entrez_hs.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\refseq_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/refseq_entrez_mm.rds"),
 )
 
 
 ## A UniProt example
 # Prep I: set up UniProt Fasta(s) if not yet
 library(proteoQDA)
-db_path <- "~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot"
+db_path <- "~/proteoQ/dbs/fasta/uniprot"
 copy_uniprot_hs(db_path)
 copy_uniprot_mm(db_path)
 
 # Prep II: copy metadata and PSMs if not yet
-dat_dir <- "~\\\\proteoQ\\\\custom_uniprot_lookups"
+dat_dir <- "~/proteoQ/custom_uniprot_lookups"
 copy_global_exptsmry(dat_dir)
 copy_global_fracsmry(dat_dir)
 
@@ -140,23 +140,23 @@ simulUniprotPSM(MaxQuant)
 
 # --- workflow begins ---
 library(proteoQ)
-dat_dir <- "~\\\\proteoQ\\\\custom_uniprot_lookups"
+dat_dir <- "~/proteoQ/custom_uniprot_lookups"
 load_expts()
 
 # prepare UniProt-to-Entrez lookups
 Uni2Entrez(species = human)
 Uni2Entrez(species = mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/uniprot_entrez_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/uniprot_entrez_mm.rds")))
 
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot\\\\uniprot_hs_2014_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot\\\\uniprot_mm_2014_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\uniprot_entrez_hs.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\uniprot_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/uniprot/uniprot_hs_2014_07.fasta",
+            "~/proteoQ/dbs/fasta/uniprot/uniprot_mm_2014_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/uniprot_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/uniprot_entrez_mm.rds"),
 )
 }
 
@@ -166,18 +166,18 @@ normPSM(
 Uni2Entrez(species = this_human, abbr_species = Hs, filename = my_human.rds)
 Uni2Entrez(species = this_mouse, abbr_species = Mm, filename = my_mouse.rds)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\my_human.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\my_mouse.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/my_human.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/my_mouse.rds")))
 
 # in PSM and subsequent outputs, values under column `species` 
 #  will be shown as "this_human" or "this_mouse"
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\my_human.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\my_mouse.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/my_human.rds", 
+             "~/proteoQ/dbs/entrez/my_mouse.rds"),
 )  
 }
 
@@ -194,8 +194,8 @@ Uni2Entrez(species = "worm", abbr_species = "Ce", filename = uniprot_entrez_ce.r
 # --- PAUSE: prepare Fasta file(s) before proceeding to `normPSM`. ---
 
 normPSM(
-  fasta = "~\\\\proteoQ\\\\dbs\\\\fasta\\\\specify_your_worm.fasta",
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\uniprot_entrez_ce.rds"),
+  fasta = "~/proteoQ/dbs/fasta/specify_your_worm.fasta",
+  entrez = c("~/proteoQ/dbs/entrez/uniprot_entrez_ce.rds"),
 )
 }
 
@@ -221,12 +221,12 @@ BiocManager::install("org.Mm.eg.db")
 
 # Prep II: set up RefSeq Fasta(s) if not yet
 library(proteoQDA)
-db_path <- "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq"
+db_path <- "~/proteoQ/dbs/fasta/refseq"
 copy_refseq_hs(db_path)
 copy_refseq_mm(db_path)
 
 # Prep III: copy metadata and PSMs if not yet
-dat_dir <- "~\\\\proteoQ\\\\custom_refseq_lookups"
+dat_dir <- "~/proteoQ/custom_refseq_lookups"
 copy_global_exptsmry(dat_dir)
 copy_global_fracsmry(dat_dir)
 
@@ -237,36 +237,36 @@ copy_global_mascot(dat_dir)
 
 # --- workflow begins ---
 library(proteoQ)
-dat_dir <- "~\\\\proteoQ\\\\custom_refseq_lookups"
+dat_dir <- "~/proteoQ/custom_refseq_lookups"
 load_expts()
 
 # prepare RefSeq-to-Entrez lookups
 Ref2Entrez(species = human)
 Ref2Entrez(species = mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\refseq_entrez_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\refseq_entrez_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/refseq_entrez_mm.rds")))
 
 # overrule the default `Entrez` lookups with the custom databases
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\refseq_entrez_hs.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\refseq_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/refseq_entrez_mm.rds"),
 )
 
 
 ## A UniProt example
 # Prep I: set up UniProt Fasta(s) if not yet
 library(proteoQDA)
-db_path <- "~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot"
+db_path <- "~/proteoQ/dbs/fasta/uniprot"
 copy_uniprot_hs(db_path)
 copy_uniprot_mm(db_path)
 
 # Prep II: copy metadata and PSMs if not yet
-dat_dir <- "~\\\\proteoQ\\\\custom_uniprot_lookups"
+dat_dir <- "~/proteoQ/custom_uniprot_lookups"
 copy_global_exptsmry(dat_dir)
 copy_global_fracsmry(dat_dir)
 
@@ -282,23 +282,23 @@ simulUniprotPSM(MaxQuant)
 
 # --- workflow begins ---
 library(proteoQ)
-dat_dir <- "~\\\\proteoQ\\\\custom_uniprot_lookups"
+dat_dir <- "~/proteoQ/custom_uniprot_lookups"
 load_expts()
 
 # prepare UniProt-to-Entrez lookups
 Uni2Entrez(species = human)
 Uni2Entrez(species = mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\uniprot_entrez_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/uniprot_entrez_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/uniprot_entrez_mm.rds")))
 
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot\\\\uniprot_hs_2014_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot\\\\uniprot_mm_2014_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\uniprot_entrez_hs.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\uniprot_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/uniprot/uniprot_hs_2014_07.fasta",
+            "~/proteoQ/dbs/fasta/uniprot/uniprot_mm_2014_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/uniprot_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/uniprot_entrez_mm.rds"),
 )
 }
 
@@ -308,18 +308,18 @@ normPSM(
 Uni2Entrez(species = this_human, abbr_species = Hs, filename = my_human.rds)
 Uni2Entrez(species = this_mouse, abbr_species = Mm, filename = my_mouse.rds)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\my_human.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\entrez\\my_mouse.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/my_human.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/entrez/my_mouse.rds")))
 
 # in PSM and subsequent outputs, values under column `species` 
 #  will be shown as "this_human" or "this_mouse"
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\my_human.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\my_mouse.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/my_human.rds", 
+             "~/proteoQ/dbs/entrez/my_mouse.rds"),
 )  
 }
 
@@ -336,8 +336,8 @@ Uni2Entrez(species = "worm", abbr_species = "Ce", filename = uniprot_entrez_ce.r
 # --- PAUSE: prepare Fasta file(s) before proceeding to `normPSM`. ---
 
 normPSM(
-  fasta = "~\\\\proteoQ\\\\dbs\\\\fasta\\\\specify_your_worm.fasta",
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\uniprot_entrez_ce.rds"),
+  fasta = "~/proteoQ/dbs/fasta/specify_your_worm.fasta",
+  entrez = c("~/proteoQ/dbs/entrez/uniprot_entrez_ce.rds"),
 )
 }
 

--- a/man/anal_prnString.Rd
+++ b/man/anal_prnString.Rd
@@ -101,16 +101,16 @@ prepString(
 
 \dontrun{
 identical(
-  readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\string\\\\string_hs.rds")), 
-  readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\string\\\\my_hs.rds"))
+  readRDS(file.path("~/proteoQ/dbs/string/string_hs.rds")), 
+  readRDS(file.path("~/proteoQ/dbs/string/my_hs.rds"))
 )
 }
 
 \donttest{
 # analysis: both `human` and `mouse`
 anal_prnString(
-  db_nms = c("~\\\\proteoQ\\\\dbs\\\\string\\\\string_hs.rds",
-             "~\\\\proteoQ\\\\dbs\\\\string\\\\string_mm.rds"),
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds"),
   score_cutoff = .9,
   filter_prots_by = exprs(prot_n_pep >= 2),
 )
@@ -119,8 +119,8 @@ anal_prnString(
 # `human` only ('unknown' species will be removed)
 # OK to include both `string_hs.rds` and `string_mm.rds`
 anal_prnString(
-  db_nms = c("~\\\\proteoQ\\\\dbs\\\\string\\\\string_hs.rds",
-             "~\\\\proteoQ\\\\dbs\\\\string\\\\string_mm.rds"),
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds"),
   score_cutoff = .9,
   filter_by_sp = exprs(species == "human"),
   filter_prots_by = exprs(prot_n_pep >= 2),
@@ -129,8 +129,8 @@ anal_prnString(
 
 # `mouse` only
 anal_prnString(
-  db_nms = c("~\\\\proteoQ\\\\dbs\\\\string\\\\string_hs.rds",
-             "~\\\\proteoQ\\\\dbs\\\\string\\\\string_mm.rds"),
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds"),
   score_cutoff = .9,
   filter_by_sp = exprs(species == "mouse"),
   filter_prots_by = exprs(prot_n_pep >= 2),
@@ -141,7 +141,7 @@ anal_prnString(
 # additional filtration by `pVals` and `log2FC`; 
 # `W16_vs_W2.pVal (W16-W2)` is a column key in `Protein_pVals.txt`
 anal_prnString(
-  db_nms = "~\\\\proteoQ\\\\dbs\\\\string\\\\string_hs.rds",
+  db_nms = "~/proteoQ/dbs/string/string_hs.rds",
   score_cutoff = .9,
   filter_by_sp = exprs(species == "human", 
                        `W16_vs_W2.pVal (W16-W2)` <= 1E-6,
@@ -151,7 +151,7 @@ anal_prnString(
 )
 
 anal_prnString(
-  db_nms = "~\\\\proteoQ\\\\dbs\\\\string\\\\string_mm.rds",
+  db_nms = "~/proteoQ/dbs/string/string_mm.rds",
   score_cutoff = .9,
   filter_by_sp = exprs(species == "mouse", 
                        `W16_vs_W2.pVal (W16-W2)` <= 1E-6,

--- a/man/anal_prnTrend.Rd
+++ b/man/anal_prnTrend.Rd
@@ -338,11 +338,14 @@ cluego(
  \code{\link{pepHM}} and \code{\link{prnHM}} for heat map visualization \cr 
  \code{\link{pepCorr_logFC}}, \code{\link{prnCorr_logFC}}, \code{\link{pepCorr_logInt}} and 
  \code{\link{prnCorr_logInt}}  for correlation plots \cr 
- \code{\link{anal_prnTrend}} and \code{\link{plot_prnTrend}} for trend analysis and visualization \cr 
- \code{\link{cluego}} for the visualization of \code{\link{anal_prnTrend}} via \code{Cytoscape} \cr 
- \code{\link{anal_pepNMF}}, \code{\link{anal_prnNMF}}, \code{\link{plot_pepNMFCon}}, 
- \code{\link{plot_prnNMFCon}}, \code{\link{plot_pepNMFCoef}}, \code{\link{plot_prnNMFCoef}} and 
- \code{\link{plot_metaNMF}} for NMF analysis and visualization \cr 
+ \code{\link{anal_prnTrend}} and \code{\link{plot_prnTrend}} for trend
+ analysis and visualization \cr \code{\link{cluego}} for the visualization of
+ \code{\link{anal_prnTrend}} and \code{\link{plot_prnTrend}} via
+ \code{Cytoscape/ClueGO} \cr \code{\link{anal_pepNMF}},
+ \code{\link{anal_prnNMF}}, \code{\link{plot_pepNMFCon}},
+ \code{\link{plot_prnNMFCon}}, \code{\link{plot_pepNMFCoef}},
+ \code{\link{plot_prnNMFCoef}} and \code{\link{plot_metaNMF}} for NMF
+ analysis and visualization \cr
  
  \emph{Custom databases} \cr 
  \code{\link{Uni2Entrez}} for lookups between UniProt accessions and Entrez IDs \cr 

--- a/man/create_db_path.Rd
+++ b/man/create_db_path.Rd
@@ -8,7 +8,7 @@ create_db_path(db_path)
 }
 \arguments{
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\go"}.}
+is \code{"~/proteoQ/dbs/go"}.}
 }
 \description{
 Helper to create `db_path`

--- a/man/dl_msig.Rd
+++ b/man/dl_msig.Rd
@@ -7,7 +7,7 @@
 dl_msig(
  
     msig_url = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/c2.all.v7.0.entrez.gmt",
-  db_path = "~\\\\proteoQ\\\\dbs\\\\msig",
+  db_path = "~/proteoQ/dbs/msig",
   overwrite = FALSE
 )
 }
@@ -20,7 +20,7 @@ base. For simplicity, only files with entrez IDs will be handled;
 files of \code{c2.all.v[...].symbols.gmt} will not be parsed.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\msig"}.}
+is \code{"~/proteoQ/dbs/msig"}.}
 
 \item{overwrite}{Logical; if TRUE, overwrite the downloaded database(s). The
 default is FALSE.}

--- a/man/dl_stringdbs.Rd
+++ b/man/dl_stringdbs.Rd
@@ -6,7 +6,7 @@
 \usage{
 dl_stringdbs(
   species = "human",
-  db_path = "~\\\\proteoQ\\\\dbs\\\\string",
+  db_path = "~/proteoQ/dbs/string",
   overwrite = FALSE
 )
 }
@@ -16,7 +16,7 @@ include \code{human, mouse, rat, fly, cow, dog}. The default is
 \code{human}.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\string"}.}
+is \code{"~/proteoQ/dbs/string"}.}
 
 \item{overwrite}{Logical; if TRUE, overwrite the downloaded database(s). The
 default is FALSE.}

--- a/man/extract_raws.Rd
+++ b/man/extract_raws.Rd
@@ -17,8 +17,8 @@ Extract a list of \code{RAW} file names that can be passed to \code{frac_smry.xl
 }
 \examples{
 \dontrun{
-# Supposed that RAW MS files are stored under "~\my_raw"
-extract_raws("~\\\\my_raw")
+# Supposed that RAW MS files are stored under "~/my_raw"
+extract_raws("~/my_raw")
 }
 
 }

--- a/man/gsvaTest.Rd
+++ b/man/gsvaTest.Rd
@@ -87,7 +87,7 @@ automatically. Exemplary values include \code{anal_type = c("PCA",
 "NMF", "Purge", "Trend", ...)}.}
 
 \item{...}{\code{filter_}: Logical expression(s) for the row filtration
-against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 See also \code{\link{normPSM}} for the format of \code{filter_} statements.
 \cr \cr \code{arrange_}: Variable argument statements for the row ordering
 against data in a primary file linked to \code{df}. See also

--- a/man/labEffPSM.Rd
+++ b/man/labEffPSM.Rd
@@ -112,7 +112,7 @@ TMT labeling efficiency
 \examples{
 \donttest{
 res <- labEffPSM(
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\uniprot\\\\uniprot_mm_2014_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/uniprot/uniprot_mm_2014_07.fasta"),
 )
 }
 }

--- a/man/load_expts.Rd
+++ b/man/load_expts.Rd
@@ -106,13 +106,13 @@ experiments
 # ===================================
 # fasta (all platforms)
 library(proteoQDA)
-fasta_dir <- "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq"
+fasta_dir <- "~/proteoQ/dbs/fasta/refseq"
 dir.create(fasta_dir, recursive = TRUE, showWarnings = FALSE)
 copy_refseq_hs(fasta_dir)
 copy_refseq_mm(fasta_dir)
 
 # working directory (all platforms)
-dat_dir <- "~\\\\proteoQ\\\\examples"
+dat_dir <- "~/proteoQ/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 # metadata (all platforms)
@@ -137,7 +137,7 @@ if (!choose_one) {
 # PSM, peptide and protein processing
 # ===================================
 library(proteoQ)
-load_expts("~\\\\proteoQ\\\\examples")
+load_expts("~/proteoQ/examples")
 
 # PSM data standardization
 normPSM(
@@ -147,8 +147,8 @@ normPSM(
   annot_kinases = TRUE, 
   
   # no default and required
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
 )
 
 # optional PSM purging
@@ -221,15 +221,15 @@ prnSig(impute_na = TRUE)
 }
 
 \dontrun{
-load_expts(dat_dir = "~\\\\proteoQ\\\\examples", expt_smry = "expt_smry.xlsx")
+load_expts(dat_dir = "~/proteoQ/examples", expt_smry = "expt_smry.xlsx")
 
 # not working; `expt_smry = my_expt` is an expression
 my_expt <- "expt_smry.xlsx"
-load_expts(dat_dir = "~\\\\proteoQ\\\\examples", expt_smry = my_expt)
+load_expts(dat_dir = "~/proteoQ/examples", expt_smry = my_expt)
 
 # need unquoting; 
 # see also: https://dplyr.tidyverse.org/articles/programming.html
-load_expts(dat_dir = "~\\\\proteoQ\\\\examples", expt_smry = !!my_expt)
+load_expts(dat_dir = "~/proteoQ/examples", expt_smry = !!my_expt)
 }
 }
 \seealso{

--- a/man/load_stringdbs.Rd
+++ b/man/load_stringdbs.Rd
@@ -24,8 +24,8 @@ prepString(human)
 prepString(mouse)
 
 load_stringdbs(
-  db_nms = c("~\\\\proteoQ\\\\dbs\\\\string\\\\string_hs.rds",
-             "~\\\\proteoQ\\\\dbs\\\\string\\\\string_mm.rds")
+  db_nms = c("~/proteoQ/dbs/string/string_hs.rds",
+             "~/proteoQ/dbs/string/string_mm.rds")
 )
 }
 

--- a/man/map_to_entrez.Rd
+++ b/man/map_to_entrez.Rd
@@ -9,7 +9,7 @@ map_to_entrez(
   abbr_species = NULL,
   from = "UNIPROT",
   filename = NULL,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\entrez",
+  db_path = "~/proteoQ/dbs/entrez",
   overwrite = FALSE
 )
 }
@@ -42,7 +42,7 @@ default, the name will be determined automatically at a given
 saved as a \code{.rds} object for uses with \code{\link{prnGSPA}}.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\msig"}.}
+is \code{"~/proteoQ/dbs/msig"}.}
 
 \item{overwrite}{Logical; if TRUE, overwrite the downloaded database(s). The
 default is FALSE.}

--- a/man/map_to_entrez_os_name.Rd
+++ b/man/map_to_entrez_os_name.Rd
@@ -10,7 +10,7 @@ map_to_entrez_os_name(
   os_name = "Homo sapiens",
   from = "UNIPROT",
   filename = NULL,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\entrez",
+  db_path = "~/proteoQ/dbs/entrez",
   overwrite = FALSE
 )
 }
@@ -39,7 +39,7 @@ default, the name will be determined automatically at a given
 saved as a \code{.rds} object for uses with \code{\link{prnGSPA}}.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\entrez"}.}
+is \code{"~/proteoQ/dbs/entrez"}.}
 
 \item{overwrite}{Logical; if TRUE, overwrite the downloaded database(s). The
 default is FALSE.}

--- a/man/mergePep.Rd
+++ b/man/mergePep.Rd
@@ -27,7 +27,7 @@ tables of \code{TMTset1_LCMSinj1_Peptide_N.txt},
 with \code{pep_len > 50}. See also \code{\link{normPSM}}.}
 }
 \value{
-The primary output is in \code{...\\Peptide\\Peptide.txt}.
+The primary output is in \code{.../Peptide/Peptide.txt}.
 }
 \description{
 \code{mergePep} merges individual peptide table(s),

--- a/man/normPSM.Rd
+++ b/man/normPSM.Rd
@@ -264,8 +264,8 @@ right of a peptide sequence, e.g. \code{K.DAYYNLCLPQRPnMI~.-} \cr }
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = prot_acc,
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   
   # variable argument statement(s)
   filter_psms_at = exprs(pep_expect <= .1),
@@ -276,8 +276,8 @@ normPSM(
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = prot_acc,
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   corrected_int = TRUE,
   rm_reverses = TRUE,
   
@@ -289,8 +289,8 @@ normPSM(
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = prot_acc,
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   
   # vararg statement(s)
   filter_psms = exprs(score >= 10),
@@ -321,28 +321,28 @@ Ref2Entrez(species = mouse)
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
-  entrez = c("~\\\\proteoQ\\\\dbs\\\\entrez\\\\refseq_entrez_hs.rds", 
-             "~\\\\proteoQ\\\\dbs\\\\entrez\\\\refseq_entrez_mm.rds"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
+  entrez = c("~/proteoQ/dbs/entrez/refseq_entrez_hs.rds", 
+             "~/proteoQ/dbs/entrez/refseq_entrez_mm.rds"),
 )
 
 
 ## Not run: 
 # wrong fasta 
 normPSM(
-  fasta = "~\\\\proteoQ\\\\dbs\\\\fasta\\\\wrong.fasta",
+  fasta = "~/proteoQ/dbs/fasta/wrong.fasta",
 )
 
 # no mouse entry annotation
 normPSM(
-  fasta = "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
+  fasta = "~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
 )
 
 # bad vararg statement
 normPSM(
-  fasta = c("~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_hs_2013_07.fasta",
-            "~\\\\proteoQ\\\\dbs\\\\fasta\\\\refseq\\\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
   filter_psms_at = exprs(column_key_not_in_psm_tables <= .1),
 )
 ## End(Not run)

--- a/man/plot_prnTrend.Rd
+++ b/man/plot_prnTrend.Rd
@@ -83,7 +83,7 @@ the transparency of lines.}
 }
 \details{
 The function reads \code{Protein_Trend_[...].txt} files under the
-\code{...\\Protein\\Trend} directory.
+\code{.../Protein/Trend} directory.
 }
 \section{\code{Protein_Trend_[...].txt}}{
 

--- a/man/prepGO.Rd
+++ b/man/prepGO.Rd
@@ -9,7 +9,7 @@ prepGO(
   abbr_species = NULL,
   gaf_url = NULL,
   obo_url = NULL,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\go",
+  db_path = "~/proteoQ/dbs/go",
   type = c("biological_process", "cellular_component", "molecular_function"),
   filename = NULL,
   overwrite = FALSE
@@ -48,7 +48,7 @@ the web address will be determined automatically. Users can overwrite the
 default OBO by providing their own URL.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\go"}.}
+is \code{"~/proteoQ/dbs/go"}.}
 
 \item{type}{Character vector. The name space in gene ontology to be included.
 The default is to include all in \code{c("biological_process",
@@ -78,8 +78,8 @@ library(proteoQ)
 prepGO(human)
 prepGO(mouse)
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\go\\go_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\go\\go_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/go/go_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/go/go_mm.rds")))
 
 # `mouse` with a slim OBO
 prepGO(
@@ -106,8 +106,8 @@ prepGO(
 \dontrun{
 # enrichment analysis with custom `GO`
 prnGSPA(
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\go\\\\go_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\go\\\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
 )
 }
 }

--- a/man/prepMSig.Rd
+++ b/man/prepMSig.Rd
@@ -10,7 +10,7 @@ prepMSig(
   abbr_species = NULL,
   ortho_mart = switch(species, mouse = "mmusculus_gene_ensembl", rat =
     "rnorvegicus_gene_ensembl", human = "to_itself", "unknown"),
-  db_path = "~\\\\proteoQ\\\\dbs\\\\msig",
+  db_path = "~/proteoQ/dbs/msig",
   filename = NULL,
   overwrite = FALSE
 )
@@ -49,7 +49,7 @@ for the lookup of orthologs to \code{human} genes. For species in
 automatically unless otherwise specified.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\msig"}.}
+is \code{"~/proteoQ/dbs/msig"}.}
 
 \item{filename}{Character string; An output file name. At the \code{NULL}
 default, the name will be determined automatically at a given
@@ -71,15 +71,15 @@ library(proteoQ)
 ## the default `MSig` is `c2.all`
 # `human`; outputs under `db_path`
 prepMSig()
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_hs.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig/msig_hs.rds")))
 
 # `mouse`
 prepMSig(species = mouse, filename = msig_mm.rds)
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_mm.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig/msig_mm.rds")))
 
 # `rat`
 prepMSig(species = rat, filename = msig_rn.rds)
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_rn.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig/msig_rn.rds")))
 
 # `dog`; need `ortho_mart` for species other than `human`, `mouse` and `rat`
 # (try `?biomaRt::useMart` for a list of marts)
@@ -98,8 +98,8 @@ prepMSig(
   filename = msig_cf2.rds,
 )
 
-msig_cf <- readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_cf.rds"))
-msig_cf2 <- readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_cf2.rds"))
+msig_cf <- readRDS(file.path("~/proteoQ/dbs/msig/msig_cf.rds"))
+msig_cf2 <- readRDS(file.path("~/proteoQ/dbs/msig/msig_cf2.rds"))
 identical(msig_cf, msig_cf2)
 
 ## use an `MSig`other than the default of `c2.all`
@@ -120,8 +120,8 @@ prepMSig(
 \dontrun{
 # enrichment analysis with custom `MSig`
 prnGSPA(
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/msig/msig_hs.rds",
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
 )
 }
 

--- a/man/prepString.Rd
+++ b/man/prepString.Rd
@@ -9,7 +9,7 @@ prepString(
   links_url = NULL,
   aliases_url = NULL,
   info_url = NULL,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\string",
+  db_path = "~/proteoQ/dbs/string",
   filename = NULL,
   overwrite = FALSE
 )
@@ -44,7 +44,7 @@ the link will be determined automatically; note that users can overwrite the
 default \code{info} data by providing their own URL.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\string"}.}
+is \code{"~/proteoQ/dbs/string"}.}
 
 \item{filename}{Use system default. Otherwise, the user-provided basename will
 be prepended with \code{_ppi.tsv} for network data and \code{_expr.tsv} for

--- a/man/prnGSPA.Rd
+++ b/man/prnGSPA.Rd
@@ -129,10 +129,10 @@ require the fields of significance p-values, the \code{df} will be one of
 determined automatically by the name of the current call.}
 
 \item{...}{\code{filter_}: Logical expression(s) for the row filtration
-against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 See also \code{\link{normPSM}} for the format of \code{filter_} statements.
 \cr \cr \code{arrange_}: Variable argument statements for the row ordering
-against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 See also \code{\link{prnHM}} for the format of \code{arrange_} statements.}
 }
 \description{
@@ -378,12 +378,12 @@ prnGSPAHM(
 # custom GO databases
 # ===================================
 # start over
-unlink(file.path(dat_dir, "Protein\\\\GSPA"), recursive = TRUE, force = TRUE)
+unlink(file.path(dat_dir, "Protein/GSPA"), recursive = TRUE, force = TRUE)
 
 # prepare GO databases (see also ?prepGO)
 prepGO(
   species = human,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/goa_human.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_hs.rds,
@@ -391,28 +391,28 @@ prepGO(
 
 prepGO(
   species = mouse,
-  db_path = "~\\\\proteoQ\\\\dbs\\\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/mgi.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_mm.rds,
 )
 
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\go", "go_hs.rds")))
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\go", "go_mm.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/go", "go_hs.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/go", "go_mm.rds")))
 
 # analysis
 prnGSPA(
   impute_na = FALSE,
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\go\\\\go_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\go\\\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
 )
 
 # It is possible that the system "go_sets" may be partially different to the
 # custom GO. Be explicit on `gset_nms`; otherwise, the default of `gset_nms =
 # c("go_sets", "c2_msig")` will be applied.
 gspaMap(
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\go\\\\go_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\go\\\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
   impute_na = FALSE,
   topn = 20, 
   show_sig = pVal, 
@@ -422,28 +422,28 @@ gspaMap(
 # custom MSig databases
 # ===================================
 # start over
-unlink(file.path(dat_dir, "Protein\\\\GSPA"), recursive = TRUE, force = TRUE)
+unlink(file.path(dat_dir, "Protein/GSPA"), recursive = TRUE, force = TRUE)
 
 # prepare MSig databases (see also ?prepMSig)
 prepMSig(species = human)
 prepMSig(species = mouse)
 
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig", "msig_hs.rds")))
-head(readRDS(file.path("~\\\\proteoQ\\\\dbs\\\\msig", "msig_mm.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_hs.rds")))
+head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_mm.rds")))
 
 # analysis
 prnGSPA(
   impute_na = FALSE,
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/msig/msig_hs.rds",
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
 )
 
 # It is possible that the system "c2_msig" may be partially different to the
 # custom databases. Be explicit on `gset_nms`; otherwise, the default of
 # `gset_nms = c("go_sets", "c2_msig")` will be applied.
 gspaMap(
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\msig\\\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/msig/msig_hs.rds",
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
   impute_na = FALSE,
   topn = 20, 
   show_sig = pVal, 
@@ -451,8 +451,8 @@ gspaMap(
 
 ## put custom `prepGO`, `prepMSig` preparation into `prnGSPA` analysis
 # start over with fresh database preparation
-unlink(file.path("~\\\\proteoQ\\\\dbs\\\\go"), recursive = TRUE, force = TRUE)
-unlink(file.path("~\\\\proteoQ\\\\dbs\\\\msig"), recursive = TRUE, force = TRUE)
+unlink(file.path("~/proteoQ/dbs/go"), recursive = TRUE, force = TRUE)
+unlink(file.path("~/proteoQ/dbs/msig"), recursive = TRUE, force = TRUE)
 
 library(magrittr)
 

--- a/man/prnGSVA.Rd
+++ b/man/prnGSVA.Rd
@@ -72,7 +72,7 @@ for models without random effects and the \code{\link[lmerTest]{lmer}} will
 be used for models with random effects.}
 
 \item{...}{\code{filter_}: Logical expression(s) for the row filtration
-against data in a primary file of \code{\\Model\\Protein[_impNA]_pVals.txt}.
+against data in a primary file of \code{/Model/Protein[_impNA]_pVals.txt}.
 See also \code{\link{normPSM}} for the format of \code{filter_} statements.
 \cr \cr \code{arrange_}: Variable argument statements for the row ordering
 against data in a primary file linked to \code{df}. See also
@@ -187,8 +187,8 @@ prnGSVA(
   verbose = FALSE,
   parallel.sz = 0,
   mx.diff = TRUE,
-  gset_nms = c("~\\\\proteoQ\\\\dbs\\\\go\\\\go_hs.rds",
-               "~\\\\proteoQ\\\\dbs\\\\go\\\\go_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds"),
 )
 }
 }

--- a/man/prnHist.Rd
+++ b/man/prnHist.Rd
@@ -255,7 +255,7 @@ p <- p +
 
 p <- p + geom_vline(xintercept = 0, size = .25, linetype = "dashed")
 
-ggsave(file.path(dat_dir, "Peptide\\\\Histogram\\\\my_ggplot2.png"), 
+ggsave(file.path(dat_dir, "Peptide/Histogram/my_ggplot2.png"), 
        width = 22, height = 48, limitsize = FALSE)
 
 \dontrun{

--- a/man/prnMDS.Rd
+++ b/man/prnMDS.Rd
@@ -383,15 +383,22 @@ pepMDS(
 library(ggplot2)
 res <- prnMDS(filename = foo.png)
 
-p <- ggplot(res) +
-  geom_point(aes(x = Coordinate.1, y = Coordinate.2, colour = Color, shape = Shape, alpha = Alpha), 
-             size = 4, stroke = 0.02) + 
-  labs(title = "", x = expression("Coordinate 1"), y = expression("Coordinate 2")) +
+p <- ggplot(res, aes(x = Coordinate.1, y = Coordinate.2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(colour = Shape), linetype = 2) + 
+  labs(title = "", x = "Coordinate 1", y = "Coordinate 2") +
   coord_fixed() + 
   geom_text(aes(x = Coordinate.1, y = Coordinate.2, label = Sample_ID), color = "gray", size = 1)
 
 ggsave(file.path(dat_dir, "Protein/MDS/my_ggplot2.png"))
 
+p_fil <- ggplot(res, aes(x = Coordinate.1, y = Coordinate.2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(fill = Shape), geom = "polygon", alpha = .4) + 
+  labs(title = "", x = "Coordinate 1", y = "Coordinate 2") +
+  coord_fixed() 
+
+ggsave(file.path(dat_dir, "Protein/MDS/my_ggplot2_fil.png"))
 
 \dontrun{
 prnMDS(

--- a/man/prnMDS.Rd
+++ b/man/prnMDS.Rd
@@ -390,7 +390,7 @@ p <- ggplot(res) +
   coord_fixed() + 
   geom_text(aes(x = Coordinate.1, y = Coordinate.2, label = Sample_ID), color = "gray", size = 1)
 
-ggsave(file.path(dat_dir, "Protein\\\\MDS\\\\my_ggplot2.png"))
+ggsave(file.path(dat_dir, "Protein/MDS/my_ggplot2.png"))
 
 
 \dontrun{

--- a/man/prnPCA.Rd
+++ b/man/prnPCA.Rd
@@ -191,7 +191,7 @@ scale_log2r <- TRUE
 # peptides, all samples
 pepPCA(
   col_select = Select, 
-  filter_peps_by = exprs(pep_n_psm >= 10),
+  filter_peps_by = exprs(pep_n_psm >= 3),
   show_ids = FALSE, 
   filename = "peps_rowfil.png",
 )
@@ -376,14 +376,26 @@ res <- prnPCA(filename = foo.png)
 
 # names(res)
 
-p <- ggplot(res$pca) +
-  geom_point(aes(x = PC1, y = PC2, colour = Color, shape = Shape, alpha = Alpha), 
-             size = 4, stroke = 0.02) + 
-  labs(title = "", x = paste0("PC1 (", res$var[1], ")"), y = paste0("PC2 (", res$var[2], ")")) +
+p <- ggplot(res$pca, aes(x = PC1, y = PC2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(colour = Shape), linetype = 2) + 
+  labs(title = "", 
+       x = paste0("PC1 (", res$prop_var[1], ")"), 
+       y = paste0("PC2 (", res$prop_var[2], ")")) +
   coord_fixed() + 
-  geom_text(aes(x = PC1, y = PC2, label = Sample_ID), color = "gray", size = 1)
+  geom_text(aes(label = Sample_ID), color = "gray", size = 1)
 
 ggsave(file.path(dat_dir, "Protein/PCA/my_ggplot2.png"))
+
+p_fil <- ggplot(res$pca, aes(PC1, PC2)) +
+  geom_point(aes(colour = Color, shape = Shape, alpha = Alpha), size = 4, stroke = 0.02) + 
+  stat_ellipse(aes(fill = Shape), geom = "polygon", alpha = .4) + 
+  labs(title = "", 
+       x = paste0("PC1 (", res$prop_var[1], ")"), 
+       y = paste0("PC2 (", res$prop_var[2], ")")) +
+  coord_fixed() 
+
+ggsave(file.path(dat_dir, "Protein/PCA/my_ggplot2_fil.png"))
 
 \dontrun{
 prnPCA(

--- a/man/prnPCA.Rd
+++ b/man/prnPCA.Rd
@@ -383,7 +383,7 @@ p <- ggplot(res$pca) +
   coord_fixed() + 
   geom_text(aes(x = PC1, y = PC2, label = Sample_ID), color = "gray", size = 1)
 
-ggsave(file.path(dat_dir, "Protein\\\\PCA\\\\my_ggplot2.png"))
+ggsave(file.path(dat_dir, "Protein/PCA/my_ggplot2.png"))
 
 \dontrun{
 prnPCA(

--- a/man/prnSig.Rd
+++ b/man/prnSig.Rd
@@ -93,8 +93,8 @@ filtration against data in a primary file of \code{Peptide[_impNA].txt} or
 }
 \value{
 The primary output is
- \code{~\\dat_dir\\Peptide\\Model\\Peptide_pVals.txt} for peptide data or
- \code{~\\dat_dir\\Protein\\Model\\Protein_pVals.txt} for protein data. At
+ \code{~/dat_dir/Peptide/Model/Peptide_pVals.txt} for peptide data or
+ \code{~/dat_dir/Protein/Model/Protein_pVals.txt} for protein data. At
  \code{impute_na = TRUE}, the corresponding outputs are
  \code{Peptide_impNA_pvals.txt} or \code{Protein_impNA_pvals.txt}.
 }

--- a/man/proc_gaf.Rd
+++ b/man/proc_gaf.Rd
@@ -8,7 +8,7 @@ proc_gaf(db_path, fn_gaf)
 }
 \arguments{
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\go"}.}
+is \code{"~/proteoQ/dbs/go"}.}
 
 \item{fn_gaf}{filename according to \code{gaf_url}}
 }

--- a/man/proc_gmt.Rd
+++ b/man/proc_gmt.Rd
@@ -35,7 +35,7 @@ automatically unless otherwise specified.}
 \item{fn_gmt}{filename of downloaded gmt results.}
 
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\msig"}.}
+is \code{"~/proteoQ/dbs/msig"}.}
 
 \item{filename}{Character string; An output file name. At the \code{NULL}
 default, the name will be determined automatically at a given

--- a/man/proc_obo.Rd
+++ b/man/proc_obo.Rd
@@ -12,7 +12,7 @@ proc_obo(
 }
 \arguments{
 \item{db_path}{Character string; the local path for database(s). The default
-is \code{"~\\proteoQ\\dbs\\go"}.}
+is \code{"~/proteoQ/dbs/go"}.}
 
 \item{fn_obo}{filename according to \code{obo_url}}
 

--- a/man/proteoQ.Rd
+++ b/man/proteoQ.Rd
@@ -31,6 +31,6 @@ analysis.
   plot_pepNMFCon, plot_prnNMFCon, plot_pepNMFCoef, plot_prnNMFCoef,
   plot_metaNMF, anal_prnTrend, plot_prnTrend, pepSig, prnSig, pepVol, prnVol,
   prnGSPA, prnGSPAHM, gspaMap, anal_prnString, pepImp, prnImp, prnGSVA,
-  prnGSEA
+  prnGSEA, cluego
 }
 

--- a/man/proteo_hm.Rd
+++ b/man/proteo_hm.Rd
@@ -106,7 +106,7 @@ proteo_hm(
   df = Protein_delta.txt, 
   id = gene, 
   df_meta = hm_meta.xlsx, 
-  filepath = file.path(dat_dir, "Protein\\\\Heatmap"), 
+  filepath = file.path(dat_dir, "Protein/Heatmap"), 
   filename = "kin_delta.png",
   complete_cases = FALSE, 
   annot_cols = NULL, 

--- a/man/reorder_files.Rd
+++ b/man/reorder_files.Rd
@@ -4,7 +4,7 @@
 \alias{reorder_files}
 \title{Re-order file names}
 \usage{
-reorder_files(filelist, n_TMT_sets)
+reorder_files(filelist)
 }
 \arguments{
 \item{filelist}{A list of file names.}

--- a/man/standPep.Rd
+++ b/man/standPep.Rd
@@ -74,7 +74,7 @@ number of iterations allowed; \cr \code{epsilon}, tolerance limit for
 declaring algorithm convergence.}
 }
 \value{
-The primary output is in \code{...\\Peptide\\Peptide.txt}.
+The primary output is in \code{.../Peptide/Peptide.txt}.
 }
 \description{
 \code{standPep} standardizes peptide results from \code{\link{mergePep}} with
@@ -318,7 +318,7 @@ pepHist(scale_log2r = TRUE, col_select = BI_1, filename = mc.png)
 pepHist(scale_log2r = TRUE, col_select = BI_1, filter_ = exprs(gene == "GAPDH"), filename = mcGAPDH.png)
 
 # heat map for `BI_1` samples
-# (outputs under `Peptide\Heatmap` folder; for help, ?pepHM)
+# (outputs under `Peptide/Heatmap` folder; for help, ?pepHM)
 pepHM(
   col_select = BI_1, 
   xmin = -2,

--- a/man/standPrn.Rd
+++ b/man/standPrn.Rd
@@ -73,7 +73,7 @@ number of iterations allowed; \cr \code{epsilon}, tolerance limit for
 declaring algorithm convergence.}
 }
 \value{
-The primary output is in \code{...\\Protein\\Protein.txt}.
+The primary output is in \code{.../Protein/Protein.txt}.
 }
 \description{
 \code{standPrn} standardizes protein results from \code{\link{Pep2Prn}} with
@@ -309,7 +309,7 @@ prnHist(scale_log2r = TRUE, col_select = BI_1, filename = mc.png)
 prnHist(scale_log2r = TRUE, col_select = BI_1, filter_ = exprs(gene == "GAPDH"), filename = mcGAPDH.png)
 
 # heat map
-# (outputs under `Protein\Heatmap` folder; for help, ?pepHM)
+# (outputs under `Protein/Heatmap` folder; for help, ?pepHM)
 prnHM(
   col_select = BI_1, 
   xmin = -2,

--- a/vignettes/README.Rmd
+++ b/vignettes/README.Rmd
@@ -117,8 +117,8 @@ RefSeq databases of human and mouse were used in the MS/MS searches against the 
 
 ```{r copy_fasta, include = TRUE, eval = FALSE}
 library(proteoQDA)
-copy_refseq_hs("~\\proteoQ\\dbs\\fasta\\refseq")
-copy_refseq_mm("~\\proteoQ\\dbs\\fasta\\refseq")
+copy_refseq_hs("~/proteoQ/dbs/fasta/refseq")
+copy_refseq_mm("~/proteoQ/dbs/fasta/refseq")
 ```
 
 #### 1.1.2 PSM data
@@ -146,7 +146,7 @@ copy_global_sm()
 To illustrate, I copy over Mascot PSMs to a working directory, `dat_dir`:  
 
 ```{r copy_global_mascot, include = TRUE, eval = FALSE}
-dat_dir <- "~\\proteoQ\\examples"
+dat_dir <- "~/proteoQ/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 copy_global_mascot(dat_dir)
 ```
@@ -209,7 +209,7 @@ As a final step of the setup, we will load the experimental summary into a work 
 
 ```{r load_proteoQ, include = TRUE, eval = FALSE}
 library(proteoQ)
-load_expts("~\\proteoQ\\examples")
+load_expts("~/proteoQ/examples")
 ```
 
 ### 1.2 PSM summarization
@@ -223,8 +223,8 @@ We start the section by processing the PSM files exported directly from `Mascot`
 normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   rptr_intco = 1000,
   rm_craps = TRUE,
   rm_krts = FALSE,
@@ -733,6 +733,27 @@ system.file("extdata", "workflow_base.R", package = "proteoQ")
 
 Another good place to get started is via the help `?load_expts`. More workflow scripts are under construction.  
 
+### 1.6 Quick start
+For quick demonstrations, steps in data preprocessing can be bypassed:  
+
+```{r quick_start, include = TRUE, eval = FALSE}
+unzip(system.file("extdata", "demo.zip", package = "proteoQDA"), 
+      exdir = "~/proteoq_bypass", overwrite  = FALSE)
+
+# file.exists("~/proteoq_bypass/proteoQ/examples/Peptide/Peptide.txt")
+# file.exists("~/proteoq_bypass/proteoQ/examples/Protein/Protein.txt")
+
+library(proteoQ)
+load_expts("~/proteoq_bypass/proteoQ/examples")
+
+# Exemplary protein MDS
+prnMDS(
+  show_ids = FALSE, 
+  width = 8,
+  height = 4,
+)
+```
+
 ## 2 Basic informatics
 In this section I illustrate the following applications of `proteoQ`:  
   
@@ -947,14 +968,14 @@ my_theme <- theme_bw() + theme(
 )
 
 p <- ggplot(res$pca) +
-  geom_point(aes(x = Coordinate.1, y = Coordinate.2, colour = Color, shape = Shape, 
+  geom_point(aes(x = PC1, y = PC2, colour = Color, shape = Shape, 
                  alpha = Alpha), size = 4, stroke = 0.02) + 
   scale_y_continuous(breaks = seq(5, 15, by = 5)) + 
-  labs(title = "", x = paste0("PC1 (", res$var[1], ")"), y = paste0("PC2 (", res$var[2], ")")) +
+  labs(title = "", x = paste0("PC1 (", res$prop_var[1], ")"), y = paste0("PC2 (", res$prop_var[2], ")")) +
   coord_fixed() + 
   my_theme
 
-ggsave(file.path(dat_dir, "Protein\\PCA\\nocent_2.png"), width = 6, height = 4)
+ggsave(file.path(dat_dir, "Protein/PCA/nocent_2.png"), width = 6, height = 4)
 ```
 
 
@@ -1168,7 +1189,7 @@ The gene sets of `GO` and `MSig` are availble for species human, mouse and rat i
 ```{r prepGO, eval = FALSE}
 prepGO(
   species = human,
-  db_path = "~\\proteoQ\\dbs\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/goa_human.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_hs.rds,
@@ -1176,14 +1197,14 @@ prepGO(
 
 prepGO(
   species = mouse,
-  db_path = "~\\proteoQ\\dbs\\go",
+  db_path = "~/proteoQ/dbs/go",
   gaf_url = "http://current.geneontology.org/annotations/mgi.gaf.gz",
   obo_url = "http://purl.obolibrary.org/obo/go/go-basic.obo",
   filename = go_mm.rds,
 )
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\go", "go_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\go", "go_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/go", "go_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/go", "go_mm.rds")))
 ```
 
 Similarly, we prepare custom `MSig` data bases for `human` and `mouse`:  
@@ -1191,7 +1212,7 @@ Similarly, we prepare custom `MSig` data bases for `human` and `mouse`:
 ```{r prepMSig, eval = FALSE}
 prepMSig(
   # msig_url = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/c2.all.v7.0.entrez.gmt",
-  # db_path = "~\\proteoQ\\dbs\\msig",
+  # db_path = "~/proteoQ/dbs/msig",
   species = human,
   filename = msig_hs.rds,
 )
@@ -1199,20 +1220,20 @@ prepMSig(
 prepMSig(
   # msig_url = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release/7.0/c2.all.v7.0.entrez.gmt",
   # ortho_mart = mmusculus_gene_ensembl, 
-  # db_path = "~\\proteoQ\\dbs\\msig",  
+  # db_path = "~/proteoQ/dbs/msig",  
   species = mouse,
   filename = msig_mm.rds,
 )
 
-# head(readRDS(file.path("~\\proteoQ\\dbs\\msig", "msig_hs.rds")))
-# head(readRDS(file.path("~\\proteoQ\\dbs\\msig", "msig_mm.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_hs.rds")))
+# head(readRDS(file.path("~/proteoQ/dbs/msig", "msig_mm.rds")))
 ```
 
 We need to provide the list name of `ortho_mart` for species other than human, mouse and rat. The value will be used for ortholog lookups via [`biomaRt`](https://bioconductor.org/packages/release/bioc/html/biomaRt.html). More details are available in the help document via `?prepMSig`. Note that the data bases will be stored as `.rds` files, which can be used with `prnGSPA` and `gspaMap` for analysis and visualization:  
 
 ```{r prnGSPA_custom_go, eval = FALSE}
 # start over
-unlink(file.path(dat_dir, "Protein\\GSPA"), recursive = TRUE, force = TRUE)
+unlink(file.path(dat_dir, "Protein/GSPA"), recursive = TRUE, force = TRUE)
 
 prnGSPA(
   impute_na = FALSE,
@@ -1220,17 +1241,17 @@ prnGSPA(
   logFC_cutoff = log2(1.2),
   gspval_cutoff = 5E-2,
   gslogFC_cutoff = log2(1.2), 
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_hs.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds", 
+               "~/proteoQ/dbs/msig/msig_hs.rds", 
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
 )
 
 gspaMap(
-  gset_nms = c("~\\proteoQ\\dbs\\go\\go_hs.rds",
-               "~\\proteoQ\\dbs\\go\\go_mm.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_hs.rds", 
-               "~\\proteoQ\\dbs\\msig\\msig_mm.rds"),
+  gset_nms = c("~/proteoQ/dbs/go/go_hs.rds",
+               "~/proteoQ/dbs/go/go_mm.rds", 
+               "~/proteoQ/dbs/msig/msig_hs.rds", 
+               "~/proteoQ/dbs/msig/msig_mm.rds"),
   impute_na = FALSE,
   show_labels = FALSE, 
   gspval_cutoff = 5E-2, 
@@ -1545,7 +1566,7 @@ The following performs the [`STRING`](http://www.string-db.org) analysis of prot
 
 ```{r Protein StringDB, eval = FALSE}
 anal_prnString(
-  db_path = "~\\proteoQ\\dbs\\string",
+  db_path = "~/proteoQ/dbs/string",
   score_cutoff = .9,
   filter_by_sp = exprs(species %in% c("human", "mouse")), 
   filter_prots_by = exprs(prot_n_pep >= 2),
@@ -1557,7 +1578,7 @@ The results of protein-protein interaction is summarised in `Protein_String_[...
 ```{r Protein String_download, eval = FALSE}
 dl_stringdbs(
   species = rat,
-  db_path = "~\\proteoQ\\dbs\\string", 
+  db_path = "~/proteoQ/dbs/string", 
 )
 ```
 
@@ -1574,7 +1595,7 @@ We first copy data over to the file directory specified by `temp_dir`, followed 
 
 ```{r W2 reference, eval = FALSE}
 # exemplary data
-temp_dir <- "~\\proteoQ\\ref_w2"
+temp_dir <- "~/proteoQ/ref_w2"
 dir.create(temp_dir, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -1589,8 +1610,8 @@ load_expts(temp_dir, expt_smry_ref_w2.xlsx)
 normPSM(
   group_psm_by = pep_seq,
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   rptr_intco = 1000,
   rm_craps = TRUE,
   rm_krts = FALSE,
@@ -1621,7 +1642,7 @@ knitr::include_graphics(c(img_pep_ref_w2))
 We alternatively seek a "center-of-mass" representation for uses as references. We select one `WHIM2` and one `WHIM16` from each 10-plex TMT. The `proteoQ` tool will average the signals from designated references. Thefore, the derived reference can be viewed as a mid point of the `WHIM2` and the `WHIM16` proteomes. We next perform analogously the data summary and histogram visualization.  
 
 ```{r W2_and_W16 reference, eval = FALSE}
-temp_dir_w2w16 <- "~\\proteoQ\\ref_w2w16"
+temp_dir_w2w16 <- "~/proteoQ/ref_w2w16"
 dir.create(temp_dir_w2w16, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -1635,8 +1656,8 @@ load_expts(temp_dir_w2w16, expt_smry_ref_w2_w16.xlsx)
 normPSM(
   group_psm_by = pep_seq,
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   rptr_intco = 1000,
   rm_craps = TRUE,
   rm_krts = FALSE,
@@ -1670,7 +1691,7 @@ In this section, we explore the effects of reference choices on the CV of `log2F
 ```{r W2 reference on CV, eval = FALSE}
 # continue on the `ref_w2` example in section 3.1.1
 library(proteoQ)
-load_expts("~\\proteoQ\\ref_w2", expt_smry_ref_w2.xlsx, frac_smry.xlsx)
+load_expts("~/proteoQ/ref_w2", expt_smry_ref_w2.xlsx, frac_smry.xlsx)
 
 # `BI_1` subset for visualization
 purgePep(
@@ -1728,7 +1749,7 @@ The CPTAC publication contains both global and phosphopeptide data from the same
 
 ```{r phosphopeptide subsets reference, eval = FALSE}
 # exemplary data
-dat_dir <- "~\\proteoQ\\phospho_stoichiometry"
+dat_dir <- "~/proteoQ/phospho_stoichiometry"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -1745,8 +1766,8 @@ load_expts()
 normPSM(
   group_psm_by = pep_seq_mod,
   group_pep_by = gene, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta", 
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"), 
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta", 
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"), 
   filter_peps = exprs(pep_expect <= .1), 
 )
 
@@ -1882,7 +1903,7 @@ and informatic analyses. In this section, we will first add a column, `n_not_na`
 
 ```{r custom_columns_bad, eval = FALSE}
 # add a column to "Protein.txt"
-df <- readr::read_tsv(file.path(dat_dir, "Protein\\Protein.txt")) 
+df <- readr::read_tsv(file.path(dat_dir, "Protein/Protein.txt")) 
 
 library(magrittr)
 n_not_na <- df %>% 
@@ -1895,14 +1916,14 @@ n_not_na <- df %>%
 df %>% 
   dplyr::mutate(n_not_na = n_not_na) %>% 
   # proteoQ::reorderCols2() %>% 
-  readr::write_tsv(file.path(dat_dir, "Protein\\Protein.txt"))
+  readr::write_tsv(file.path(dat_dir, "Protein/Protein.txt"))
 ```
 
 Note that there is a restriction in column additions in that the custom column(s) need to be anchored before the *intensity* and *ratio* fields for uses in downstream analyses. This is achieved behind the scene when the modified file is loaded, for example, in protein heat map visualization:  
 
 ```{r custom_columns_bad2, eval = FALSE}
 prnHM(
-  df = "Protein\\Protein.txt", 
+  df = "Protein/Protein.txt", 
   xmin = -1,
   xmax = 1,
   xmargin = 0.1,
@@ -1921,7 +1942,7 @@ prnHM(
 )
 ```
 
-Importantly, we need to supply the file name to argument `df`. This is because a higher precedence will be given to `Model\\Protein_pVals.txt` over `Protein.txt`. Without specifying the value of `df`, proteoQ will look for the `n_not_na` column that are indeed absent from `Protein_pVals.txt`.  
+Importantly, we need to supply the file name to argument `df`. This is because a higher precedence will be given to `Model/Protein_pVals.txt` over `Protein.txt`. Without specifying the value of `df`, proteoQ will look for the `n_not_na` column that are indeed absent from `Protein_pVals.txt`.  
 
 ```{r custom_cols_heatmap, echo=FALSE, fig.align='center', fig.cap="**Figure S2E.** Scarce heat map.", fig.show='hold', message=FALSE, warning=FALSE, out.width='60%'}
 img_na_hm <- "images/protein/heatmap/mostly_na_vals.png"
@@ -1931,7 +1952,7 @@ knitr::include_graphics(c(img_na_hm))
 Alternatively, we may add the custom column to `Protein_pVals.txt`:  
 
 ```{r custom_columns, eval = FALSE}
-df <- readr::read_tsv(file.path(dat_dir, "Protein\\Model\\Protein_pVals.txt")) 
+df <- readr::read_tsv(file.path(dat_dir, "Protein/Model/Protein_pVals.txt")) 
 
 n_not_na <- df %>% 
   dplyr::select(grep("Z_log2_R", names(.))) %>% 
@@ -1942,10 +1963,10 @@ n_not_na <- df %>%
 
 df %>% 
   dplyr::mutate(na_counts = na_counts) %>% 
-  readr::write_tsv(file.path(dat_dir, "Protein\\Model\\Protein_pVals.txt"))
+  readr::write_tsv(file.path(dat_dir, "Protein/Model/Protein_pVals.txt"))
 
 prnHM(
-  df = "Protein\\Model\\Protein_pVals.txt", 
+  df = "Protein/Model/Protein_pVals.txt", 
   xmin = -1,
   xmax = 1,
   xmargin = 0.1,
@@ -1974,7 +1995,7 @@ In proteomic studies involved multiple multiplex `TMT` experiments, the limited 
 We start off by (re)executing the reduced example shown in `?load_expts`:  
 
 ```{r load_expts_example, eval = FALSE}
-dat_dir <- "~\\proteoQ\\randeffs\\examples"
+dat_dir <- "~/proteoQ/randeffs/examples"
 dir.create(dat_dir, recursive = TRUE, showWarnings = FALSE)
 
 library(proteoQDA)
@@ -1989,8 +2010,8 @@ normPSM(
   group_psm_by = pep_seq_mod, 
   group_pep_by = gene, 
   annot_kinases = TRUE, 
-  fasta = c("~\\proteoQ\\dbs\\fasta\\refseq\\refseq_hs_2013_07.fasta",
-            "~\\proteoQ\\dbs\\fasta\\refseq\\refseq_mm_2013_07.fasta"),
+  fasta = c("~/proteoQ/dbs/fasta/refseq/refseq_hs_2013_07.fasta",
+            "~/proteoQ/dbs/fasta/refseq/refseq_mm_2013_07.fasta"),
 )
 
 PSM2Pep()
@@ -2053,7 +2074,7 @@ prnSig(
 )
 
 # correlation plots
-read.csv(file.path(dat_dir, "Protein\\Model\\Protein_pVals.txt"), 
+read.csv(file.path(dat_dir, "Protein/Model/Protein_pVals.txt"), 
          check.names = FALSE, header = TRUE, sep = "\t") %>%
   dplyr::select(grep("pVal\\s+", names(.))) %>% 
   `colnames<-`(c("none", "one", "two")) %>% 


### PR DESCRIPTION
# 2020-06-20
Fixes: 
  - In various analysis, handled the exception that `Reference` samples were selected under `expt_smry.xlsx::Select`. 

Updates:
  - Supported non-sequential `TMT_Set` and `LCMS_Injection` indexes in the metadata files of `expt_smry.xlsx` and `frac_smry.xlsx`. 
    This enables convenient removals of entire `TMT_Set` and/or `LCMS_Injection` without reindexing.
  - Added examples in MDS and PCA analysis.
  - Exported outputs in correlation analysis.
  - Added section 1.6 `Quick start` for an exmple of bypassing data preprocessing (for demonstration only).