### PR TITLE
2020-06-22

### DIFF
--- a/R/nmf.R
+++ b/R/nmf.R
@@ -462,16 +462,17 @@ plotNMFCoef <- function(id, rank, label_scheme_sub, scale_log2r, complete_cases,
     attr(clus, "Ordered") <- NULL
     attr(clus, "call") <- NULL
     attr(clus, "class") <- NULL
-    clus <- data.frame(clus, check.names = FALSE)
+    clus <- clus %>% data.frame(check.names = FALSE) 
     
     if (!all(is.na(annotation_col))) {
-      annotation_col <- annotation_col %>% 
-      tibble::rownames_to_column() %>% 
-      dplyr::bind_cols(clus) %>% 
-      dplyr::select(-c("neighbor", "sil_width")) %>% 
-      dplyr::rename(silhouette = cluster) %>% 
-      dplyr::mutate(silhouette = factor(silhouette)) %>% 
-      tibble::column_to_rownames()
+      annotation_col <- suppressMessages(
+        annotation_col %>% 
+          tibble::rownames_to_column() %>% 
+          dplyr::left_join(clus %>% tibble::rownames_to_column(), id = "rowname") %>% 
+          dplyr::select(-c("neighbor", "sil_width")) %>% 
+          dplyr::rename(silhouette = cluster) %>% 
+          dplyr::mutate(silhouette = factor(silhouette)) %>% 
+          tibble::column_to_rownames())
     }
 
     p <- my_pheatmap(

--- a/R/peptable.R
+++ b/R/peptable.R
@@ -9,15 +9,17 @@
 #' @importFrom magrittr %>%
 newColnames <- function(i, x, label_scheme) {
   label_scheme_sub <- label_scheme %>%
-    dplyr::filter(TMT_Set == i)
+    dplyr::filter(TMT_Set == i) # %>% 
+    # dplyr::arrange(TMT_Channel)
   
   cols <- grep(paste0("[RI][0-9]{3}[NC]{0,1}_", i, "$"), names(x))
   nm_channel <- gsub(paste0("([RI][0-9]{3}[NC]{0,1})_", i, "$"), "\\1", names(x)[cols])
   names(x)[cols] <- paste0(nm_channel, " (", as.character(label_scheme_sub$Sample_ID), ")")
   
+  # update the column indexes with TMT_Set being replaced with Sample_ID
   cols <- grep("[RI][0-9]{3}[NC]{0,1}\\s+\\(.*\\)$", names(x))
   
-  # cols with new names go first
+  # cols with the updated names go first
   if (length(cols) < ncol(x)) x <- dplyr::bind_cols(x[, cols], x[, -cols, drop = FALSE])
   
   return(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1851,6 +1851,13 @@ filters_in_call <- function (df, ...) {
     
     if (!rlang::is_list(row_exprs)) row_exprs <- list(row_exprs)
     
+    row_exprs <- map(row_exprs, ~ {
+      is_char <- is.character(.x)
+      if (is_char) .x <- rlang::sym(.x)
+      
+      return(.x)
+    })
+    
     row_vals <- row_exprs %>% 
       purrr::map(eval_tidy, df) %>% 
       purrr::reduce(`&`, .init = 1)
@@ -1883,6 +1890,13 @@ arrangers_in_call <- function(.df, ..., .na.last = TRUE) {
       rlang::eval_bare()
     
     if (!rlang::is_list(row_orders)) row_orders <- list(row_orders)
+    
+    row_orders <- purrr::map(row_orders, ~ {
+      is_char <- is.character(.x)
+      if (is_char) .x <- rlang::sym(.x)
+      
+      return(.x)
+    })
     
     order_call <- rlang::expr(order(!!!row_orders, na.last = !!.na.last))
     ord <- rlang::eval_tidy(order_call, .df)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 proteoQ
 ================
 true
-2020-06-18
+2020-06-22
 
   - [Introduction to proteoQ](#introduction-to-proteoq)
   - [Installation](#installation)
@@ -1226,6 +1226,8 @@ We first visualize MDS and Euclidean distance against the peptide data.
 We start with metric MDS for peptide data (`prnMDS` for proteins):
 
 ``` r
+dat_dir <- "~/proteoQ/examples"
+
 # all data
 pepMDS(
   show_ids = FALSE,
@@ -2456,7 +2458,7 @@ plot_metaNMF(
   # cellwidth = 6,
   # cellheight = 6,
   cluster_rows = FALSE,
-  arrange_by = exprs("gene"),   
+  arrange_by = exprs(gene),   
   filename = bi_r5_rowordered.png,
 )
 ```

--- a/inst/extdata/examples/prnNMF_.R
+++ b/inst/extdata/examples/prnNMF_.R
@@ -140,7 +140,7 @@ plot_pepNMFCon(
   col_select = BI,
   annot_cols = c("Color", "Alpha", "Shape"),
   annot_colnames = c("Lab", "Batch", "WHIM"),
-  color = colorRampPalette(brewer.pal(n = 7, name = "Spectral"))(50), 
+  color = colorRampPalette(RColorBrewer::brewer.pal(n = 7, name = "Spectral"))(50), 
   width = 10,
   height = 10,
   filename = bi.pdf,

--- a/vignettes/README.Rmd
+++ b/vignettes/README.Rmd
@@ -766,6 +766,8 @@ Unless otherwise mentioned, the `in-function filtration` of data by varargs of `
 We first visualize MDS and Euclidean distance against the peptide data. We start with metric MDS for peptide data (`prnMDS` for proteins):  
 
 ```{r Peptide MDS, eval = FALSE}
+dat_dir <- "~/proteoQ/examples"
+
 # all data
 pepMDS(
   show_ids = FALSE,
@@ -1530,7 +1532,7 @@ plot_metaNMF(
   # cellwidth = 6,
   # cellheight = 6,
   cluster_rows = FALSE,
-  arrange_by = exprs("gene"),   
+  arrange_by = exprs(gene),   
   filename = bi_r5_rowordered.png,
 )
 ```


### PR DESCRIPTION
Fixes:
  - In the plotting of NMF coefficient matrix via `plot_prnNMFCoef`, fixed the bug that the binding of `silhouette` clustering data may fail when only partial sample IDs were selected via `col_select = ...`.
  - In the `vararg` filtration and ordering of data rows, handled the cases such that `arrange_ = exprs("gene")` instead of the recommended `arrange_ = exprs(gene)` without the quotation marks;
    changed the NMF example in online README from `plot_metaNMF(arrange_by = exprs("gene"), ...)` to `plot_metaNMF(arrange_by = exprs(gene), ...)`