### PR TITLE
20201015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ blogdown
 public
 R/Copy
 R/New folder
+R/Others
 R/temp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: proteoQ
 Title: Data Processing and Informatic Analysis of  Spectrometrirc Data
-Version: 1.2.8.3
+Version: 1.2.8.4
 Authors@R: 
     person(given = "Qiang",
            family = "Zhang",

--- a/R/.Rhistory
+++ b/R/.Rhistory
@@ -1,0 +1,69 @@
+devtools::document(("C:/Results/R/proteoQ"))
+load_expts("C:/Results/Silva/005_tmt_test")
+prnHist(
+scale_log2r = TRUE,
+cut_points = c(mean_lint = NA),
+xmin = -2,
+xmax = 2,
+ncol = 10,
+filename = test.png,
+)
+scale_log2r = TRUE,
+cut_points = c(prot_acc = NA),
+xmin = -2,
+xmax = 2,
+ncol = 10,
+filename = test.png,
+)
+prnHist(
+scale_log2r = TRUE,
+cut_points = c(mean_lint = NA),
+xmin = -2,
+xmax = 2,
+ncol = 10,
+filename = test.png,
+)
+prnHist(
+scale_log2r = TRUE,
+# cut_points = c(mean_lint = NA),
+cut_points = c(prot_acc = NA),
+xmin = -2,
+xmax = 2,
+ncol = 10,
+filename = test.png,
+)
+prnHist(
+scale_log2r = TRUE,
+# cut_points = c(mean_lint = NA),
+cut_points = c(prot_acc = NA),
+xmin = -2,
+xmax = 2,
+ncol = 10,
+filename = test.png,
+)
+cut_points
+set_cutpoints2(cut_points, df)
+set_cutpoints2(cut_points, df)
+cut_points
+cut_points
+cut_nm
+cut_nm %in% names(df)
+str(df[[cut_nm]])
+is.numeric(df[[cut_nm]])
+! is.numeric(df[[cut_nm]])
+cut_nm
+stop(cut_nm, " is not numeric.", call. = FALSE)
+stop("Column `", cut_nm, "` is not numeric.", call. = FALSE)
+devtools::document(("C:/Results/R/proteoQ"))
+devtools::document(("C:/Results/R/proteoQ"))
+prnHist(
+scale_log2r = TRUE,
+# cut_points = c(mean_lint = NA),
+cut_points = c(prot_acc = seq(0, 1, .25)),
+xmin = -2,
+xmax = 2,
+ncol = 10,
+filename = test.png,
+)
+cut_points
+cut_points <- set_cutpoints2(cut_points, df)

--- a/R/corrplots.R
+++ b/R/corrplots.R
@@ -407,9 +407,9 @@ pepCorr_logInt <- function (col_select = NULL, col_order = NULL,
 #'
 #' code{prnCorr_logFC} plots Pearson correlation for protein \code{logFC}.
 #'
-#' With TMT experiments, the same peptide sequence may be triggered any where
-#' between the baseline and the apex of a peak profile. The comparison of
-#' intensity between plex-es would probably have a very different or little
+#' With TMT experiments, the same polypeptide may be triggered for MS2 any where
+#' between the baseline and the apex levels during a peak elution. The direct
+#' comparison of reporter-ion intensities between plex-es might have little
 #' meaning.
 #'
 #'@inheritParams prnHist

--- a/R/normalization.R
+++ b/R/normalization.R
@@ -182,6 +182,7 @@ normMulGau <- function(df, method_align, n_comp, seed = NULL, range_log2r, range
       unlist() %>%
       data.frame(x = .) %>%
       tibble::rownames_to_column("Sample_ID") %>%
+      dplyr::filter(.data$Sample_ID %in% label_scheme$Sample_ID) %>% 
       dplyr::mutate(Sample_ID = factor(Sample_ID, levels = label_scheme$Sample_ID)) %>%
       dplyr::arrange(Sample_ID) %>% 
       dplyr::mutate(x = ifelse(is.na(x), NA, 0))

--- a/R/psmtable.R
+++ b/R/psmtable.R
@@ -3258,12 +3258,14 @@ pad_mq_channels <- function(file, fasta, entrez) {
     df <- local({
       df <- df %>% dplyr::mutate(prot_acc = gsub(";.*$", "", Proteins))
       
-      tempdata <- df %>% 
-        dplyr::select(prot_acc) %>% 
-        dplyr::filter(!duplicated(prot_acc)) %>% 
-        annotPrn(fasta, entrez) %>% 
-        dplyr::select(prot_acc, gene, prot_desc) %>% 
-        dplyr::rename(`Gene Names` = "gene", "Protein Names" = "prot_desc")
+      tempdata <- suppressWarnings(
+        df %>% 
+          dplyr::select(prot_acc) %>% 
+          dplyr::filter(!duplicated(prot_acc)) %>% 
+          annotPrn(fasta, entrez) %>% 
+          dplyr::select(prot_acc, gene, prot_desc) %>% 
+          dplyr::rename(`Gene Names` = "gene", "Protein Names" = "prot_desc")
+      )
       
       df <- df %>% 
         dplyr::left_join(tempdata, by = "prot_acc") %>% 

--- a/man/pep_mq_lfq2.Rd
+++ b/man/pep_mq_lfq2.Rd
@@ -4,7 +4,7 @@
 \alias{pep_mq_lfq2}
 \title{Total, razor and unique intensity of peptides}
 \usage{
-pep_mq_lfq2()
+pep_mq_lfq2(label_scheme)
 }
 \description{
 Temporary handling using MaxQuant peptide.txt.

--- a/man/prnCorr_logFC.Rd
+++ b/man/prnCorr_logFC.Rd
@@ -124,9 +124,9 @@ code{prnCorr_logFC} plots Pearson correlation for protein \code{logFC}.
 of ions for protein data.
 }
 \details{
-With TMT experiments, the same peptide sequence may be triggered any where
-between the baseline and the apex of a peak profile. The comparison of
-intensity between plex-es would probably have a very different or little
+With TMT experiments, the same polypeptide may be triggered for MS2 any where
+between the baseline and the apex levels during a peak elution. The direct
+comparison of reporter-ion intensities between plex-es might have little
 meaning.
 }
 \examples{


### PR DESCRIPTION
Bugs
 - Fixed duplicated fasta entries due to partial data filtration by accession types.
   The duplication may cause memory failure for large data sets.
 - In the calculation of various protein coverages,
   separated `suppressWarnings()` from pipes (%>%) blocks for code robustness.
 - In MaxQuant LFQ of `PSM2Pep(...)` and `Pep2Prn(...)`,
   handled the case that sample(s) were removed from `meta_data (label_scheme.xlsx)` but not from `MaxQuant peptides.txt`, 
   and followed by a data summarization method of `lfq_...`.