### PR TITLE
2022-03-30

### DIFF
--- a/R/peptable.R
+++ b/R/peptable.R
@@ -947,10 +947,10 @@ spreadPepNums <- function (df, filelist, group_psm_by)
   } 
   
   df_num <- df_num %>%
-    dplyr::arrange_at(cols_grp2) %>%
     tidyr::gather(grep("R[0-9]{3}|I[0-9]{3}", names(.)), key = ID, value = value) %>%
+    dplyr::arrange_at(cols_grp2) %>%
     tidyr::unite(ID, c(ID, cols_grp2))
-
+  
   # define the levels of TMT channels;
   # otherwise, the order of channels will flip between N(itrogen) and C(arbon)
   Levels <- unique(df_num$ID)


### PR DESCRIPTION
Bugs:
- One line of code in `mergePep` need an immediate fix!!! This occurred after the latest addition of SILAC workflows with the generalization from `dplyr::arrange` to `dplyr::arrange_at` (need to report the bug where data rows were not ordered as intended followed by tidyr::gather).  

Without the fix, the order of samples will be incorrect!

More checks are forthcoming in a next commit.